### PR TITLE
Update documentation of Flexibility section to align it with ETM updates

### DIFF
--- a/docs/main/flexibility.md
+++ b/docs/main/flexibility.md
@@ -2,95 +2,67 @@
 title: Flexibility
 ---
 
-Natural patterns like seasons (yearly), the variations in weather (weekly), day and night and our rhythm of waking up, going to work, coming home, etc. cause both the need for energy and the availability of energy to fluctuate. Flexibility is about balancing energy supply and demand on all of these timescales. In the ETM you have the ability to choose and adjust how you deal with these fluctuations in the ['Flexibility'](https://pro.energytransitionmodel.com/scenario/flexibility/flexibility_overview/what-is-flexibility) section. On this page, you can gain an understanding of the ETM charts in the flexibility section which show how supply and demand compare on various timescales. 
+Natural patterns like seasons (yearly), the variations in weather (weekly), day and night and our rhythm of waking up, going to work, coming home, etc. cause both the need for energy and the availability of energy to fluctuate. Flexibility is about balancing energy supply and demand on all of these timescales. In the ETM you have the ability to choose and adjust how you deal with these fluctuations in the ['Flexibility'](https://pro.energytransitionmodel.com/scenario/flexibility/flexibility_overview/what-is-flexibility) section. On this page, concepts relevant for understanding flexibility are defined.
 
-## Flexibility solutions based on different types of energy fluctuations
-For longer timescales, the amount or volume of energy supplied or used is more interesting. For shorter timescales, the ability to produce or use a certain amount of energy is more interesting. This is called capacity.
+## Flexibility for different types of energy fluctuations
+A first distinction to make when looking into flexibility, is to decide whether it is required for longer or for shorter timescales. For longer timescales, the amount or **volume** of energy supplied or used is more interesting. For shorter timescales, the ability to produce or use a certain amount of energy is more interesting. This is called **capacity**. For a typical energy system fluctuations occur on both timescales, and enough flexibility should be provided for both volume and capacity.
 
-Some forms of flexibility are more suite to process large (fluctuations in) volumes of energy, others are more suitable for large fluctuations in capacity. Only some are suited to both. Some examples are:
+Some forms of flexibility are more suited to process large (fluctuations in) volumes of energy, others are more suitable for large fluctuations in capacity. Only some are suited to both. Some examples are:
 
-Suitable for large (fluctuations in) volume
+_Suitable for large (fluctuations in) volume_
 * Imports/exports of gas/hydrogen
-* Power-to-gas: hydrogen production from excess power
+* Power-to-gas: hydrogen production from excess electricity
 * Storage of gas/hydrogen
 * Seasonal storage of heat
 
-Suitable for large or sudden (fluctuations in) capacity
+_Suitable for large or sudden (fluctuations in) capacity_
 * Storage in lithium-ion batteries
-* Storage in flywheels 
 * Dispatchable power and heat plants 
 * Demand side response
 
-Suitable for both volume and capacity
+_Suitable for both volume and capacity_
 * Imports/exports of electricity
-* Power-to-heat: heat production from excess power (with heat storage)
-* Curtailment of renewable power production
-* Large-scale electricity storage: pumped hydro storage 
+* Power-to-heat: heat production from excess electricity (with heat storage)
+* Curtailment of renewable electricity production
+* Large-scale electricity storage: pumped hydro storage
 
-For these comparisons the contributions of flexibility technologies such as those mentioned above are deliberately not shown. Only the baseload demand and inflexible supply is shown, meaning the demand and supply that is independent of other technologies in the energy system. In this way, you can see how large the mismatch between supply and demand is, and therefore, the need for flexibility solutions. For a full overview of the exact definitions of inflexible supply and baseload demand see the section [Definitions of inflexible supply and baseload demand](#definitions-of-inflexible-supply-and-baseload-demand).
+## Definitions of flexible and inflexible supply and demand
+The different forms of flexiblity listed above indicate that there are also types of supply and demand that are **inflexible**. In the ETM this distinction between inflexible and flexible supply and inflexible (or *baseload*) and flexible demand is explained in the section about ['Hourly inflexible supply and demand'](https://pro.energytransitionmodel.com/scenario/flexibility/flexibility_overview/hourly-inflexible-supply-and-demand):
 
-Once you have evaluated the need for flexibility in your scenario, you can address this need by tuning the amount of flexible technologies you have installed in your scenario, for example in the ['Excess electricity'](https://pro.energytransitionmodel.com/scenario/flexibility/excess_electricity/order-of-flexibility-options) section in the ETM. An overview of these technologies can be found on the ['Excess electricity'](excess-electricity.md) infopage.
+* Inflexible supply: this is the energy produced by technologies that cannot be regulated easily by humans or that run continuously based on cost considerations. Wind and solar are good examples of technologies that cannot be regulated by humans. They do show variable behaviour (volatile changes due to environmental effects) but they for instance do not follow hourly electricity prices. We therefore call them inflexible. Nuclear power plants are an example of power plants that can be adjusted to run continuously based on cost considerations. These kind of plants are called must-run.
+* Flexible supply: this energy production typically *does* follow man-made rules (such as hourly electricity prices) and includes so-called *dispatchable plants* like gas-fired power plants.
+* Inflexible (or *baseload*) demand: this type of energy consumption is considered fixed because it cannot be regulated easily. This for example includes industrial processes that need to run continuously, or consumption that does not respond to hourly electricity prices such as individual households. Most of the final electricity demand of sectors falls into this category.
+* Flexible demand: this is energy consumption that can be increased, reduced, or shifted in time if needed.
 
-## Chart 1: Monthly supply and demand volumes
+Two important additions to these definitions are addressed here. First, it is important to understand that the classification of technologies as flexible or inflexible, is based on their representation in the ETM. Some technologies that may be flexible in reality, can be modelled in such a way that they are considered inflexible in the ETM. For example, the import of natural gas can be considered flexible in reality, but in the ETM it is represented as a flat curve and therefore classified as inflexible.
 
-![Chart 1: Monthly supply and demand volumes](/img/docs/20210202_Monthly_supply_and_demand_volumes.png)
+Second, a _systems_ perspective is used to classify technologies as flexible or inflexible. This means that when a technology is considered flexible for a specific energy carrier, it is also considered flexible for all other energy carriers. An example of where this distinction is relevant is power-to-heat. This technology is a form of electricity demand that can be used to balance supply and demand in the electricity network, typically when supply exceeds demand. From the perspective of the energy carrier electricity, it is therefore considered a flexible technology because it follows man-made rules. Because we use the _systems_ perspective, power-to-heat is then also considered a flexible technology for all other energy carriers, including heat for district heating.
 
-This chart shows the monthly total <i>volumes</i> for supply and demand of electricity, gas, hydrogen and heat. This gives you insight into the balance of your energy system throughout the year: when does imbalance occur? Which carriers are not in balance?
+## The need for flexibility
+In the ETM, we have made selection of charts available that can give you insight in the need for flexibility in the energy system. These charts are intended to give you a sense of the mismatch between supply and demand on various timescales, for the energy carriers electricity, gas, hydrogen, and heat for district heating. These charts are accompanied by explanatory texts that build your understanding of the need for flexibility in a logical order. If you are interested in exploring the need for flexiblity in your scenario, we therefore recommend starting at the ['Overview'](https://pro.energytransitionmodel.com/scenario/flexibility/flexibility_overview/what-is-flexibility).
 
-## Chart 2: Imbalance of monthly supply and demand volumes
+Keep in mind that the definitions used to classify flexible and inflexible technologies described above, affect what is shown in the charts. In the paragraph below you can find a complete overview of which technologies are flexible, and which are inflexible, for the four energy carriers defined above.
 
-![Chart 2: Imbalance of monthly supply and demand volumes](/img/docs/20210202_Imbalance_of_monthly_supply_and_demand_volumes.png)
-
-This chart shows the monthly imbalance between supply and demand <i>volumes</i> for electricity, gas,
-hydrogen and heat. The imbalance is calculated by subtracting the inflexible supply from the baseload demand, this is called the "residual load". Negative values mean "surpluses" of energy and positive values "shortages". This chart gives insight into the balance of your energy system throughout the year: in which months does an imbalance occur? Which carriers are not in balance? Are these shortages or surpluses of energy?
-
-## Chart 3: The need for flexibility: volume
-
-![Chart 3: The need for flexibility: volume](/img/docs/20210202_The_need_for_flexibility_volume.png)
-
-This chart gives a rough estimate for how much long-term flexibility (storage volume) is needed in your scenario. The blue (“uncorrected”) line in the chart is created by summing up the hourly imbalance for all relevant carriers at each hour. This curve is indicative because losses of storage or conversion are not taken into account.
-
-This curve gives a general impression of the extent to which the energy system is in balance over the year. In periods where demand exceeds supply (cold periods with no wind and little sunshine), the resulting curve dips as ‘storage’ gets depleted. In periods where supply is generally higher than demand (like sunny summer months), the curve rises again.
-
-By comparing the start and end point of this line, you can see whether the system is in surplus or deficit on an annual basis. The absolute difference shows how much room there is for surplus storage or surplus conversion losses to make up for any shortages, or how large the shortage is that needs to be filled with additional energy production or imports.
-
-The red (“corrected”) line shows the fluctuations in required storage volume if supply and demand would balance out over the year. This gives a rough estimate of your total required storage capacity to ensure that carriers can be used at the right time. This total required storage capacity can be read from the highest value of this line.
-
-This line is obtained by subtracting the annual surplus/deficit from the blue line. Because the cumulative nature of the curve, the correction of first hour is added to the correction of the second hour etc. until the last hour is corrected to coincide with the level of the first hour.
-
-## Chart 4: The need for flexibility: capacity
-
-![Chart 4: The need for flexibility: capacity](/img/docs/20210202_The_need_for_flexibility_capacity.png)
-
-This chart shows the monthly maximum <i>capacity</i> for supply and demand of electricity, gas, hydrogen and heat. This gives an indication of the capacity needed to deal with imbalance for each energy carrier. This capacity can be realized in the form of transport infrastructure or other flexibility options. For the electricity network the relation between transport infrastructure and flexibility options can be explored in more detail in the [Net load section in the ETM](https://pro.energytransitionmodel.com/scenario/flexibility/flexibility_net_load/peak-load-and-usable-capacity).
-
-## Definitions of inflexible supply and baseload demand
-
-For the comparisons in the flexibility charts above the contributions of flexibility technologies are deliberately not shown. Only the baseload demand and inflexible supply is shown, meaning the demand and supply that is independent of other technologies in the energy system. This way, you can see how large the mismatch between supply and demand, and therefore, the need for flexibility is.
-
-Technologies are defined as flexible when they are deployed to ensure the hourly balance of the <i>energy system</i>. Dispatchable power plants for example are considered flexible because they only produce electricity to the extent that electricity shortages exist, and therefore balance the electricity system. Since the balance of the energy system as a whole is most interesting, any technology that contributes to the balance of a single energy carrier is considered a flexible technology for all energy carriers. This means for example that power-to-heat, which contributes to the balance of the electricity system, is also considered a flexible technology for district heating.
-
-It is important to note that the categorization of technologies according to the definition of flexible technologies given above, is done based on the representation of each technology in the ETM. For example, the import of natural gas can be seen as a flexible technology in reality, but in the ETM it is represented as a flat curve and it is therefore categorized as an inflexible technology.
-
+## Categorization of flexible and inflexible technologies
 ### Electricity
 
 See the [Flexibility → Excess electricity](https://pro.energytransitionmodel.com/scenario/flexibility/excess_electricity/order-of-flexibility-options) section of the model.
 
-#### Inflexible supply
+#### Supply
 
-* Includes:
+* Inflexible:
   * Must-run / volatile: wind turbines, solar panels, hydro power, must-run nuclear plants
-* Excludes:
+* Flexible:
   * Dispatchable power plants
   * Batteries discharging: household batteries, vehicle-to-grid, large-scale batteries, etc.
   * Import
 
-#### Baseload demand
+#### Demand
 
-* Includes:
+* Inflexible (baseload):
   * Final electricity demand in sectors
   * Must-run heat pumps / boilers for district heating
-* Excludes:
+* Flexible:
   * Batteries charging: household batteries, vehicle-to-grid, large-scale batteries etc.
   * Conversion: power-to-hydrogen, power-to-heat (for industry or district heating)
   * Curtailment
@@ -98,22 +70,22 @@ See the [Flexibility → Excess electricity](https://pro.energytransitionmodel.c
 
 ### Gas
 
-#### Inflexible supply
+#### Supply
 
-* Includes:
+* Inflexible:
   * Production green gas and LNG (flat curve)
   * Extraction natural gas (flat curve)
   * Import of natural gas (flat curve; constant import of gas to balance yearly production of gas)
-* Excludes:
+* Flexible:
   * Gas from storage (in the ETM, gas is automatically buffered throughout the year)
 
-#### Baseload demand
+#### Demand
 
-* Includes:
+* Inflexible (baseload):
   * Final gas demand in sectors
   * Export of gas (flat curve; constant export of gas to balance yearly production of gas)
   * Distribution losses
-* Excludes:
+* Flexible:
   * Gas used in dispatchable power plants and heat boilers for district heating
   * Gas entering storage (in the ETM, gas is automatically buffered throughout the year)
 
@@ -121,44 +93,44 @@ See the [Flexibility → Excess electricity](https://pro.energytransitionmodel.c
 
 See the [Supply → Hydrogen](https://pro.energytransitionmodel.com/scenario/supply/hydrogen/hydrogen-production) section of the model.
 
-#### Inflexible supply
+#### Supply
 
-* Includes:
+* Inflexible:
   * Must-run / volatile: dedicated offshore wind turbine or solar PV plant for H2, steam methane reforming, biomass gasification
   * Import of hydrogen (flat curve; constant import of hydrogen to balance yearly production of hydrogen)
-* Excludes:
+* Flexible:
   * Hydrogen from storage (in the ETM, hydrogen is automatically buffered throughout the year)
   * Hydrogen produced by power-to-gas
 
-#### Baseload demand
+#### Demand
 
-* Includes:
+* Inflexible (baseload):
   * Final hydrogen demand in sectors
   * Export of hydrogen (flat curve; constant export of hydrogen to balance yearly production of gas)
   * Distribution losses
-* Excludes:
+* Flexible:
   * Hydrogen used in dispatchable power plants and heat boilers for district heating
   * Hydrogen entering storage (in the ETM, gas is automatically buffered throughout the year)
 
-### District heating
+### Heat for district heating
 
 See the [Supply → District heating](https://pro.energytransitionmodel.com/scenario/supply/heat/heat-sources) section of the model.
 
-#### Inflexible supply
+#### Supply
 
-* Includes:
+* Inflexible:
   * Must-run / volatile: solar thermal, residual heat from industry, geothermal heat
   * Import of heat (flat curve)
-* Excludes:
+* Flexible:
   * Heat produced by power-to-heat
   * Heat produced by CHPs, as CHPs participate as dispatchable power plants in the electricity merit order
   * Dispatchable heat sources: collective heat pump, hydrogen heater, etc.
   * Heat from seasonal storage
 
-#### Baseload demand
+#### Demand
 
-* Includes:
+* Inflexible (baseload):
   * Final heat demand in sectors
   * Losses: distribution losses, heat surplus (wasted)
-* Excludes:
+* Flexible:
   * Heat entering seasonal storage


### PR DESCRIPTION
I have rewritten part of the Flexibility documentation to align it with final changes made to the 'need for flexibility' narrative in the ETM. The structure of the updated documentation is as follows:

- Introduction to flexibility and defining the goal of the documentation [minor changes]
- Distinction between flexibility for volume and flexibility for capacity [minor changes]
- Distinction between inflexible and flexible supply and demand [expanded, major changes]
- Explanation of the purpose of the 'need for flexibility' narrative [slimmed down, major changes]
- Overview of flexible and inflexible technologies for the energy carriers [minor changes]

@marliekeverweij can you check what you think of this updated documentation?
One of the key things that I have changed is removing the explanation of each chart in the 'need for flexibility' narrative, because these are already explained in the ETM and are therefore redundant. Instead I have simply outlined the purpose of the narrative, so please check whether you think it has added value.