### PR TITLE
Port scenario-tools readme to docs

### DIFF
--- a/docs/main/scenario-tools/advanced-settings.md
+++ b/docs/main/scenario-tools/advanced-settings.md
@@ -1,0 +1,33 @@
+---
+title: Advanced settings
+---
+## ETM environments
+The ETM knows a live and a beta environment. The scenario-tools naturally connect to the first one. In the
+beta environment experimental features are available for testing, before being included in the
+live version. This makes the beta version more unstable. You can also run the ETM locally, check the
+[contributors section](/contrib/intro) for more info.
+
+When running any of the scripts in the scenario-tools, you can add the arguments `beta` or `local`
+to create or query scenarios on the ETM [beta server](https://beta-pro.energytransitionmodel.com/)
+or your local machine. The latter assumes your local engine runs at `localhost:3000` and local
+model at `localhost:4000`, but you can change this in `config/settings.yml` at any time. I.e.:
+```
+pipenv run scenario_from_csv beta
+```
+or
+```
+python scenario_from_csv.py local
+```
+
+## Configuring the tool
+
+You can change three different kinds of settings in the configuration file `config/settings.yml`: input/output folder settings, settings for [when you run the model locally](#etm-environments), and CSV settings. Here is a quick overview:
+
+| Setting | What does it do? | Default value |
+| --- | --- | --- |
+| `input_file_folder` | Location of the main input files, this can be a full path to anywhere on your computer. | `data/input`|
+| `input_curves_folder` | Location of where the curve files you wish to use are stored, this can be a full path to anywhere on your computer. | `data/input/curves`|
+| `output_file_folder` | Location of where all output files should be written to by the tools. Again, this can be a full path to any folder on your computer. | `data/output` |
+|`local_engine_url`| The url to ETEngine that should be used when you use the `local` option in the tools. | `http://localhost:3000/api/v3` |
+|`local_model_url`| The url to ETModel that should be used when you use the `local` option in the tools. | `http://localhost:4000` |
+| `csv_separator` | The separator your CSV files are using. Some European computers use ';' instead of ','. | , |

--- a/docs/main/scenario-tools/creating-and-updating.md
+++ b/docs/main/scenario-tools/creating-and-updating.md
@@ -1,0 +1,85 @@
+---
+title: Creating and updating scenarios
+---
+
+## How does it work?
+Next to retrieving data from existing scenarios, the tools also allow you to create or update scenarios
+based on your data. When you add a name, area and end year to the [`scenario_list`](#scenario_listcsv), but
+no ID, a new scenario will be created for you and the ID will be filled in automatically when running the
+tools.
+
+Next to that, you can include slider settings for each scenario, custom curves, a heat network order
+and settings for heat demand curves.
+
+## Setting up the CSV input files
+To create and update ETM scenarios you can edit two CSV files in the input folder. The [`scenario_list`](#scenario_listcsv) CSV contains general information about the scenarios, such as the region and target year. And secondly, the [`scenario_settings`](#scenario_settingscsv) file contains the ETM slider values for each of the scenarios specified in `scenario_list.csv`.
+
+Moreover, you can supply custom demand, supply and price curves for your scenarios in the [`input/curves`](#curves) folder.
+
+### scenario_list.csv
+In the `scenario_list.csv` file you can create a row for each scenario you wish to process. The CSV contains the following columns:
+ * **short_name**. Here you can specify an identifier for each scenario. NOTE: short_names must be unique!
+ * **title**. Scenario title. This is displayed in the ETM front-end.
+ * **area_code**. Scenario region. A full list of available area codes can be found on [Github](https://github.com/quintel/etsource/tree/production/datasets).
+ * **end_year**. The target year / year of interest of each scenario.
+ * **description**. Scenario description. This is displayed in the model’s front-end.
+ * **id**. Should be left empty if you want to create a new scenario. The ID will be filled in automatically when the scenario is created. If you want to update an existing scenario, you can specify its ID here.
+ * **protected**. *Optional.* Either `TRUE` or `FALSE`. If set to `TRUE`, the scenario will be frozen.
+  This means that no one will be able to change or update any of the settings, including yourself.
+  The scenario will still be queryable. If left empty, it defaults to `FALSE`.
+ * **curve_file**. The name of a CSV file containing custom hourly profiles. For example interconnector price curves, solar production curves or industry heat demand curves. The CSV file should be placed in the `input/curves` folder.
+ * **heat_network_order**. To specify the order in which dispatchable district heating technologies are utilised if there is a shortage of supply. Can be left empty to use the default order. Options should be separated by a space. E.g.: `"energy_heat_network_storage energy_heat_burner_hydrogen”`. The full list of technologies can be found on [Github](https://github.com/quintel/etsource/blob/production/config/heat_network_order.yml).
+ * **heat_demand**. *Optional - expert feature.* The name of the folder inside `input/curves` that contains either 15 heat demand profiles, or the three input files neccesary to generate new profiles. See the [heat module section](heat-module) for more information.
+
+
+### scenario_settings.csv
+The `scenario_settings.csv` file contains the slider settings of your scenarios. The first column contains the keys of all sliders (‘inputs’) that will be set. If a slider is missing from this list, it will inherit the default value. The default value is the value the slider is on when starting a new scenario. The other columns contain the scenario `short_names` (specified in `scenario_list.csv`) and the corresponding slider values. A list of all slider keys can be found [here](https://pro.energytransitionmodel.com/saved_scenarios/10114.csv) (CSV file).
+
+*Example file:*
+
+| input  | scenario_short_name_1   | scenario_short_name_2   |
+|---|---|---|
+| households_number_of_residences  | 40000  | 37000  |
+| transport_useful_demand_passenger_kms  | -1.5  | 2.3  |
+| transport_vehicle_using_electricity_efficiency  | 0  | 1.2  |
+
+### curves
+In the `input/curves` folder you can add custom demand, supply and price curves to use in your scenarios. These curves can be used to overwrite the default ETM [profiles](https://docs.energytransitionmodel.com/main/curves#modifying-profiles). In the `scenario_list.csv` file you specify for each scenario which CSV curve file to use by adding the file name to the `curve_file` column.
+
+Each file should look as follows:
+ * The first row of each column should contain the key of the category you want to upload a custom curve for. A full ist of available keys can be found on [Github](https://github.com/quintel/etsource/blob/production/config/user_curves.yml). Example: *interconnector_1_price*
+ * Row 2-8761 should contain the hourly values (one for each hour per year)
+ * You can add multiple columns to customize multiple profiles
+ * You can add multiple CSV files in case you want to use different profiles for different scenarios
+
+ *Example file:*
+
+| interconnector_1_price  | industry_chemicals_heat |
+|---|---|
+| 23.4 | 0.023
+| 30.4 | 0.021
+| 31.2 | 0.034
+| 9.8 | 0.045
+| ... | ...
+
+
+## Running the tool
+
+:::info Automatic data retrieval
+Please mind that the data retrieval step is run
+automatically after creating or updating the scenarios. You can clear the rows in the data retrieval
+files for [results](retrieving-data#queriescsv) and [data downloads](retrieving-data#datadownloadscsv)
+if you don't want this behaviour.
+:::
+
+The tool can be run with the following commands.
+
+With `pipenv` you can run:
+```
+pipenv run scenario_from_csv
+```
+
+With basic Python:
+```
+python scenario_from_csv.py
+```

--- a/docs/main/scenario-tools/creating-templates.md
+++ b/docs/main/scenario-tools/creating-templates.md
@@ -1,0 +1,30 @@
+---
+title: Create a scenario template
+---
+## How does it work?
+It's also possible to adopt the settings of an existing scenario, which we then call a scenario template.
+
+The script will create a `template_settings.csv` file in the `output/` folder. This file provides an overview of all slider settings for each scenario template. To adopt the values, open the `adopt_template_settings.xlsx` file located in the `data` folder and copy paste the entire sheet into the `template_settings` sheet. In the `adopter` sheet you can choose which scenario template should be used by specifying the template scenario ID. Also, you can choose which scenario settings to adopt by specifying TRUE or FALSE for each input key. By default, all settings are adopted except for the ones representing a capacity (in MW). When you're done, replace the [`input/scenario_settings.csv`](creating-and-updating#scenariosettingscsv) by the sheet `scenario_settings` from the Excel file. You can then use these settings to [create or update a scenario](creating-and-updating).
+
+## Setting up the input CSV files
+For running this part of the tool only one input CSV file is needed: the one that specifies from which
+scenarios you want to create a template.
+
+### template_list.csv
+The `template_list.csv` file contains the following columns:
+
+ * **id**. Here you can specify the ETM scenario ID of the scenario template.
+ * **title**. Here you can add a title for the template which is also displayed in the template settings output file.
+
+## Running the tool
+You can run the template script in your console with the following commands.
+
+With `pipenv`:
+```
+pipenv run get_template_settings
+```
+
+Or with basic Python:
+```
+python get_template_settings.py
+```

--- a/docs/main/scenario-tools/heat-module.md
+++ b/docs/main/scenario-tools/heat-module.md
@@ -1,0 +1,23 @@
+---
+title: Heat module
+---
+
+## How does it work?
+The ETM allows for the uploading of 15 types of heat demand profiles for households. This submodule can
+generate these for you based on thermostat and weather data. When the `heat_demand` column was
+filled in for the scenario in the [`scenario_list` file](creating-and-updating#scenario_listcsv),
+these profiles will be created and uploaded when you create or update a scenario with the tool.
+
+## Setting up the modules input files
+You can supply a custom subfolder in the `input/curves` folder which contains either heat demand curves, or ways to generate these heat demand curves:
+
+  1. **Supply your own heat demand curves** In this subfolder, supply csv profiles (summing to 1/3600) for all combinations of the following house types and insulation levels: *"terraced_houses", "corner_houses", "semi_detached_houses", "apartments", "detached_houses"* and *"low", "medium", "high"*. The names of the csv files should look like *insulation_apartments_low*. All 15 files should be present. Or;
+  2. **Generate heat demand curves** To generate your own heat demand profiles and upload them, three input csv files should be present in the subfolder:
+     - temperature: The outside temperature in degrees C for all 8760 hours of the year;
+     - irradiation: The irradiation in J/cm2 for all 8760 hours of the year;
+     - thermostat: A csv with three columns (*low, medium, high*), with thermostat settings for  24 hours.
+
+  The generated curves will be written to the subfolder, and can be inspected and reused.
+
+The tool will checkout your subfolder and decide for itself which of the two paths to follow. If the 15 profiles are there, these will be used. If the three input files are present, new curves will be generated.
+

--- a/docs/main/scenario-tools/introduction.md
+++ b/docs/main/scenario-tools/introduction.md
@@ -1,0 +1,76 @@
+---
+title: Introduction
+---
+## What are the scenario-tools?
+The scenario-tools are a small collection of tools written in Python that allow ETM users to
+communicate to the ETM without accessing the web-interface. Input and output data is all
+in CSV format for easy incorporation in Excel workflows.
+
+You can download or clone the tools from [our Github](https://github.com/quintel/scenario-tools).
+
+To run the tools a Python installation is required, but working the tool requires no prior knowlegde
+of that programming language.
+
+With the tool you can:
+- [Download scenario results and query e.g. dashboard items](retrieving-data.md)
+- [Create or update scenario slider settings and custom curves](creating-and-updating.md)
+- [Create a template of a scenario which you can use to create new sceanrios](creating-templates.md)
+- [Create a regional overview combining multiple scenarios](regional-overview.md)
+
+## Input and output
+The scenario-tools read input data, such as slider settings or requested downloads, from several CSVs
+that you must supply. This section gives a quick overview of what to expect.
+
+By default, and when you first look at the tool after downloading it, the `input` and `output` folders are located in the `data` folder. The tool will read and write to the files in these folders when you run it. If you want the input data to be read from another location on your computer,
+or the output data to be written to another folder, you can change this in the [settings](advanced-settings.md#configuring-the-tool). Please note that the tool will still expect the input file names to stay the same.
+
+### Input
+:::info Dummy data in the input files
+All input files contain dummy data, to give you an actual example of how the data should be presented. Make sure to clear the dummy data from the files when you start using the tool.
+:::
+
+Each functionality of the tool requires its own input CSVs. The neccesary files for each function will be
+described on the dedicate pages.
+
+Here is a list of the files that can be encountered in the input folder:
+ * `scenario_list.csv` - Contains general information about the scenarios, such as the region and target year
+ * `scenario_settings.csv`) - Contains the ETM slider values for each of the scenarios specified in `scenario_list.csv`
+ * `queries.csv` - Contains a list of queries (scenario outcomes) you would like to retrieve for each scenario.
+ * `data_downloads.csv` - Contains a list of data exports you would like to retrieve for each scenario.
+ * `template_list.csv` -  Contains a list of scenario templates specified by its scenario ID
+ * `regional_overview.csv` -  Contains a list of scenarios of different areas that will make up the region to be overviewed
+
+In addition, you may add CSV files containing custom supply, demand and price [curves](creating-and-updating#curves) to the `input/curves` folder.
+
+### Output
+The scripts create/update/query the scenarios in the Energy Transition Model and print the corresponding URLs in the terminal. In addition, the following is added to the `data/output` folder:
+
+ * A `scenario_outcomes.csv` file containing the query outcomes for all scenarios, including a column containing the values for the present year and the unit of each query
+ * Sub folders for each scenario `short_name` containing the data exports
+
+## Getting started
+
+Make sure you have [Python 3](https://www.python.org/downloads/) installed. Then, install all required libraries by opening a terminal/command-prompt window in the `scenario-tools` folder (or navigate to this folder in the terminal using `cd "path/to/scenario-tools-folder"`). All following examples of running the tool
+expect you to be in this folder.
+
+#### Using pipenv
+It is recommended (but not required) that you use [`pipenv`](https://pipenv.pypa.io/en/latest/) for running these tools. When using `pipenv`
+it will create a virtual environment for you. A virtual environment helps with keeping the libaries you install here separate of your global libraries (in
+other words your `scenario-tools` will be in a stable and isolated environment and are thus less likely to break when updating things elswhere on your computer)
+and this one comes with some nice shortcuts for running the tools.
+
+You can instal `pipenv` with `pip` or `pip3` if you don't have it installed yet.
+```
+pip3 install pipenv
+```
+
+Then you can create a new environment and install all the libraries in one go by running:
+```
+pipenv install
+```
+
+#### Using basic Python
+Alternatively, if you do **not** want to use `pipenv` you can also install the requirements globally by running:
+```
+pip3 install -r requirements.txt
+```

--- a/docs/main/scenario-tools/regional-overview.md
+++ b/docs/main/scenario-tools/regional-overview.md
@@ -1,0 +1,32 @@
+---
+title: Regional overview
+---
+
+## How does it work?
+When you have multiple scenarios of different adjoining areas (e.g. municipalities, or EU countries)
+that form a region together, this part of the scenario-tools allows you to create an overview of them.
+An overview consists of a CSV containing the different areas as columns and detailed information on
+for example final demand and the supply mix as rows. There is also one column where the results of each
+area are combined into a regional value.
+
+The overview will appear in the `output` folder as a CSV.
+
+## Setting up the input CSV files
+Creating the regional overview only requires the `regional_overview` csv file to be filled in.
+
+### regional_overview.csv
+In this CSV the scenario IDs and area names of the scenarios that should be part of the overview
+are listed. This is the only information needed.
+
+## Running the tool
+You can run the regional overview with the following commands.
+
+With `pipenv`:
+```
+pipenv run regional_overview
+```
+
+With basic Python:
+```
+python scripts/regional_overview.py
+```

--- a/docs/main/scenario-tools/retrieving-data.md
+++ b/docs/main/scenario-tools/retrieving-data.md
@@ -1,0 +1,70 @@
+---
+title: Retrieving scenario data
+---
+## How does it work?
+With the scenario-tools scenario data can be extracted from the ETM without having to access the
+interface and pressing the download button. The only thing you need is the ID of each scenario you
+want to extract information from.
+
+There are two main applications: extracting query information (asking questions to the graph), and
+automatic downloads. Each of these requires a different CSV file to be configured in your input folder,
+but both require you to set up the [scenario_list](#scenario_listcsv) with the correct scenario IDs.
+
+After you run the tool, the results will appear in the output folder. A folder with the `short_name` of
+the scenario will be created containing all downloaded files. And a CSV file called `scenario_outcomes`
+will be created in the main output folder containing the sceanrio(s) as columns, and the query results as rows.
+
+## Setting up the input CSV files
+For both applications, extracting query information and collecting downloads, the [scenario_list](#scenario_listcsv) file should be configured. For extracting queries the [queries](#queriescsv) file
+should be set up, and for collecting downloads the names of the downloads should be specified in the
+[data_downloads](#data_downloadscsv) file. If you will not be using either the queries or downloads, you
+can leave the rows blank.
+
+### scenario_list.csv
+Each row in this file represents an ETM scenario. The `scenario_list.csv` file contains a lot of columns, but for the purpose of extracting data all of them can be
+left blank except for the following:
+
+ * **short_name**. Here you can specify an identifier for each scenario. NOTE: `short_names` must be unique!
+ * **area_code**. Scenario region. A full list of available area codes can be found on [Github](https://github.com/quintel/etsource/tree/production/datasets).
+ * **id**. The ETM scenario ID.
+
+### queries.csv
+The `queries.csv` file contains a list of queries that will be collected for each scenario. A query is a small ‘request’ for information on a specific topic. For example, each item in the ETM’s dashboard is a query (‘total annual costs’, ‘total CO<sub>2</sub> reduction’). Similarly, each series of a chart in the ETM is a query (‘electricity demand for households space heating’, ‘gas demand for households space heating’ etc.). A list of all available queries can be found on [Github](https://github.com/quintel/etsource/tree/production/gqueries).
+
+*Example file:*
+
+| query  |
+|---|
+| dashboard_co2_emissions_versus_start_year |
+| dashboard_total_costs |
+| dashboard_blackout_hours |
+
+
+### data_downloads.csv
+The `data_downloads.csv` allows you to specify all [data export](https://pro.energytransitionmodel.com/scenario/data/data_export/energy-flows) CSVs that will be downloaded for each scenario. The file contains two columns. One column for specifying which *annual* data exports you are interested in and one column specifying the *hourly* data exports.
+
+*Example file:*
+
+| annual_data  | hourly_data |
+|---|---|
+| energy_flow | electricity_price
+| application_demands | hydrogen
+| production_parameters | heat_network
+| | household_heat
+
+
+## Running the tool
+
+For retrieving data the tool should be run in `query-only` mode.
+
+In query-only mode the scripts will only collect scenario results ([queries](#queriescsv) and [data downloads](#data_downloadscsv)). No changes will be made to existing scenarios, nor will new scenarios be created. The latter means that scenarios in the [`scenario_list.csv`](#scenario_listcsv) without an 'id' will be ignored, as these scenarios have not yet been created.
+
+With `pipenv` run:
+```
+pipenv run scenario_from_csv query_only
+```
+
+With basic Python run:
+```
+python scenario_from_csv.py query-only
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -107,13 +107,27 @@ module.exports = {
       items: ["main/energy-calculations", "main/useful-demand"],
     },
     {
+      type: "category",
+      label: "5. Scenario-tools",
+      collapsed: true,
+      items: [
+        "main/scenario-tools/introduction",
+        "main/scenario-tools/retrieving-data",
+        "main/scenario-tools/creating-and-updating",
+        "main/scenario-tools/creating-templates",
+        "main/scenario-tools/regional-overview",
+        "main/scenario-tools/heat-module",
+        "main/scenario-tools/advanced-settings",
+      ]
+    },
+    {
       type: "link",
-      label: "5. For Contributors",
+      label: "6. For Contributors",
       href: "/contrib/intro",
     },
     {
       type: "link",
-      label: "6. API Reference",
+      label: "7. API Reference",
       href: "/api/intro",
     },
   ],


### PR DESCRIPTION
We have a good [Readme](https://github.com/quintel/scenario-tools/blob/master/README.md) on the scenario-tools, however, with all the functionality that keeps on being added and more of our clients using the tool, it might be the right time to port the scenario-tools documentation to... the documentation!

The main reason of doing it now is because I had to add a chapter about the new regional overview functionality and didn't know where to put it in the current readme. So here we are.

### Content
Most of the content is directly copied from the readme. With each functionality there is a small new introductory paragraph. There is a new 'big' item in the sidebar, a new number 5, but we can of course change that if it's now too prominent. We can also name the sidebar 'Advanced Tools' and put the scenario-tools as the first item.

The tab starts with an introduction to the scenario tools and then goes into each functionality individually.


<img width="1456" alt="Screenshot 2022-04-05 at 15 24 29" src="https://user-images.githubusercontent.com/14875123/161786408-5352ec96-c5a9-453b-8c0e-5648f2b4e03f.png">
<img width="1456" alt="Screenshot 2022-04-05 at 15 24 10" src="https://user-images.githubusercontent.com/14875123/161786435-bafe51d7-fdf7-4ad5-8a4e-b3c4a80212dc.png">


### Going further...
It could be nice to include:
- a nicer CSV files view, right now normal markdown tables are used
- examples of output files


Including @redekok as she is the scenario-tools queen (but I don't expect you to review it 😉 )