### PR TITLE
Use 2030/2035 biomass potential data instead of 2014/2015

### DIFF
--- a/docs/main/biomass.md
+++ b/docs/main/biomass.md
@@ -62,10 +62,10 @@ Caution: the production costs of green gas are not optimized; this is mainly the
 TNO has researched the potential biomass production in the Netherlands for 2030:
 
 |                              | Unit | Wet biomass | Dry biomass | Oil-containing biomass | Biogenic waste |
-|------------------------------|------|-------------|-------------|-------------------------|----------------|
-| Dutch biomass potential 2030 | PJ   | 16\.8       | 47\.4       | 10\.5                   | 21\.6          |
+|------------------------------|------|-------------|-------------|------------------------|----------------|
+| Dutch biomass potential 2030 | PJ   | 109\.9      | 62\.2       | 10\.5                  | 21\.4          |
 
-These total potentials originate from the underlying biomassa streams depicted below (sorry, in Dutch only):
+These total potentials originate from the underlying biomassa streams depicted below (available in Dutch only):
 
 | Sector                                                                      | Biomassastroom                          | Categorie | Potentie PJ \(droge stof basis\) | Verdeelsleutel van nationale naar gemeentelijke potentie                                  |
 |-----------------------------------------------------------------------------|-----------------------------------------|-----------|----------------------------------|---------------------------------------------------------------------------------------|


### PR DESCRIPTION
Our [Biomass documentation](https://docs.energytransitionmodel.com/main/biomass/#dutch-biomass-potential) refers to a report of TNO to show the biomass potential of the Netherlands in 2030 in the following table:
<img width="600" alt="Screenshot 2022-12-21 at 16 24 17" src="https://user-images.githubusercontent.com/67338510/208940831-4ee44665-6ce4-498e-abc9-98dc8fc05dd8.png">

However, one client notified us that if you open the [report](https://refman.energytransitionmodel.com/publications/2100) itself, it seems like the values for 2014/2015 have been copied, instead of the ones for 2030/2035:
<img width="957" alt="Screenshot 2022-12-21 at 16 26 28" src="https://user-images.githubusercontent.com/67338510/208941302-1442d789-8d6c-419b-9e46-2a99a9206228.png">
<img width="953" alt="Screenshot 2022-12-21 at 16 26 42" src="https://user-images.githubusercontent.com/67338510/208941354-8ae8015b-5557-496c-b9e5-69bb9531d055.png">

@marliekeverweij since you were the last to update this piece of the documentation, could you please verify that I have correctly interpreted the report? If so, feel free to merge this PR.