### PR TITLE
Add propane to import-calculations and flexibility sections

### DIFF
--- a/docs/main/flexibility.md
+++ b/docs/main/flexibility.md
@@ -87,13 +87,12 @@ Flexible demand technologies are governed by a "willingness to pay": a maximum p
 * Inflexible (baseload):
   * Final gas demand in sectors
   * Gas used in dispatchable power plants and heat boilers for district heating
-  * Export of natural gas (flat curve; constant export of gas to balance yearly production of gas)
-  * Export of green gas (flat curve; constant export of gas to balance yearly production of gas)
+  * Baseload export of green gas (flat curve; constant export of gas to model transitflows)
+  * Baseload export of natural gas (flat curve; constant export of gas to model transitflows)
+  * Backup export of natural gas (flat curve; constant export of gas to balance yearly production of gas)
   * Distribution losses
 * Flexible:
   * Gas entering storage (in the ETM, gas is automatically buffered throughout the year)
-  * Export of natural gas (backup)
-  * Export of green gas (backup)
 
 ### Hydrogen
 

--- a/docs/main/import-calculations.md
+++ b/docs/main/import-calculations.md
@@ -29,12 +29,11 @@ The import is determined for the following primary energy carriers:
     -   Bio-diesel
     -   Bio-ethanol
     -   Bio-oil
-    -   Biofuel (Deprecated)
     -   Greengas
-    -   Waste (All waste including non-biogenic)
-    -   Algue diesel
-    -   Wood pellet
+    -   Biogenic waste
+    -   Wood pellets
     -   Biocoal
+-   Non-biogenic waste
 -   Heat
 
 _Note: Lignite cannot be imported from a neighboring country, as this would not be energy efficient. All lignite is therefore assumed to be locally available. For each country it is defined whether or not lignite is available for production of electricity._


### PR DESCRIPTION
This PR adds propane to the documentation:

- Mentions it as an imported carrier under import-calculations;
- Mentions its flat import profile under flexibility.