### PR TITLE
Add GQL documentation

### DIFF
--- a/docs/contrib/gql.md
+++ b/docs/contrib/gql.md
@@ -2,13 +2,19 @@
 title: Graph query language (GQL)
 ---
 
-GQL is used to calculate values that are used in the graphs, tables and figures that can be viewed in the model. Users can check values themselves by using the GQL-sandbox in ETEngine. {TO DO: update}
+GQL is used to calculate values that are used in the graphs, tables and figures that can be viewed in the model. An overview of all gqueries can be found in [this folder](https://github.com/quintel/etsource/tree/master/gqueries).
 
-## Writing gqueries
+## Gqueries
 
-Please note that the output that is printed in this documentation is dependent on the scenario the user is using. GQL is case sensitive. Since all GQL-functions are written in caps, this means that all functions **must** be written in caps in order to function. {TO DO: update}
+Gqueries are in fact stored GQL procedures that have a key. So that if the user wants to know the total co2 emissions of an area, it can request the ETEngine for gquery `total_co2_emissions` and does not have to worry about the underlying intricacies.
 
-##  Constants
+### Writing gqueries
+
+Please note that the output that is printed in this documentation is dependent on the scenario the user is using. GQL is case sensitive. Since all GQL-functions are written in caps, this means that all functions **must** be written in caps in order to function.
+
+##  Functions
+
+### Constants
 
 ```ruby
 MWH_TO_GJ = 3.6
@@ -26,8 +32,6 @@ MJ_TO_PJ = BILLIONS
 MILLIONS = 10.0**6
 THOUSANDS = 1000.0
 ```
-
-##  Functions
 
 ### Aggregate functions
 
@@ -77,7 +81,7 @@ NEG(1,2,3)
 => -1
 ```
 
-AVG(values)
+#### AVG(values)
 Returns the average of all number (ignores nil values).
 ```
 AVG(1,2)    
@@ -367,7 +371,7 @@ window_size - The number of points to average over.
 
 ### Helper functions
 
-### SORT_BY(*objects, arguments)
+#### SORT_BY(*objects, arguments)
 With SORT_BY nodes can be sorted on one of their attributes.
 The nodes will be sorted ascending to the value of the attribute.
 Ranking of the nodes will start from 0.
@@ -384,8 +388,7 @@ SORT_BY(G(useful_demand),demand)
 ]
 ```
 
-
-### TXT_TABLE(objects, *argyments)
+#### TXT_TABLE(objects, *argyments)
 With TXT_TABLE 1 or more attributes from a node group can be queried.
 The nodes in the given node group will be sorted alphabetically.
 
@@ -429,7 +432,7 @@ TXT_TABLE(SORT_BY(G(useful_demand),demand),key,demand)
 +------------------------------------------------------------------------------+--------------------+
 ```
 
-### EXCEL_TABLE(objects, *arguments)
+#### EXCEL_TABLE(objects, *arguments)
 Similar functionality to TXT_TABLE
 
 

--- a/docs/contrib/gql.md
+++ b/docs/contrib/gql.md
@@ -10,10 +10,37 @@ Gqueries are in fact stored GQL procedures that have a key. So that if the user 
 
 ### Writing gqueries
 
-Please note that the output that is printed in this documentation is dependent on the scenario the user is using. GQL is case sensitive. Since all GQL-functions are written in caps, this means that all functions **must** be written in caps in order to function.
+GQL is case sensitive. Since all GQL-functions are written in caps, this means that all functions **must** be written in caps in order to function. When writing gqueries, the following guidelines should be kept in mind:
+
+- Base gqueries are added in the `general` folder on [Github](https://github.com/quintel/etsource/tree/master/gqueries/general).
+- Other gqueries, for example gqueries used in `output_elements`, should refer to base gqueries when possible.
+- Base gqueries have a consistent set of base units, for example `MW` for **capacity** and `MJ` for **energy**.
+- Base gqueries have a consistent nomenclature: for example **type**, **subtype**, **sector**, **subsector**, **carrier**.
+- Base gqueries should have a description.
+- Gqueries indent first with 4 spaces, then with 2 spaces.
+
+Example for `final_demand_energetic_industry_steel_wood_pellets`:
+```
+# Energetic final demand of the 'coal' carrier group in industry steel sector.
+
+- query =
+    SUM(
+      V(
+        FILTER(
+          FILTER(
+            INTERSECTION(EG(final_demand),EG(appliances_households)
+            ),
+            "coal? || coal_gas? || cokes? || lignite?"
+          ),
+          "energetic?"
+        ),
+        value
+      )
+    )
+- unit = PJ
+```
 
 ##  Functions
-
 
 ### Math functions
 
@@ -23,22 +50,12 @@ The math functions consists of functions that perform mathematical operations or
 
 Returns how many values. Removes nil values, but does not remove duplicates. 
 
-*Basic example*:
-
-```ruby
-COUNT(1) 
-=> 1
-COUNT(1,2)  
-=> 2
-```
-*Node example*:
-
 ```ruby
 COUNT(V(foo,bar)) 
 => 2
 ```
 
-*multiple LOOKUPS (does not remove duplicates)*
+*Multiple LOOKUPS (does not remove duplicates)*
 
 ```ruby
 COUNT(V(foo,bar), V(foo)) 
@@ -53,9 +70,7 @@ COUNT(V(foo,bar,foo))
 
 #### NEG(values)
 
-Returns the *first* number as a negative
-
-*example*:
+Returns the *first* number as a negative.
 
 ```ruby
 NEG(2) 
@@ -67,6 +82,7 @@ NEG(1,2,3)
 
 #### AVG(values)
 Returns the average of all number (ignores nil values).
+
 ```ruby
 AVG(1,2)    
 => 1.5
@@ -80,6 +96,7 @@ AVG(1,nil,nil,2)
 
 #### SUM
 Returns the sum of all numbers (ignores nil values).
+
 ```ruby
 SUM(1,2) 
 => 3
@@ -99,10 +116,10 @@ PRODUCT(1,nil)
 => 1
 ```
 
-
 #### DIVIDE(values)
 
 Divides the first value with the second value.
+
 ```ruby
 DIVIDE(1,2)
 => 0.5
@@ -112,67 +129,78 @@ DIVIDE(1,2,3,4)
 ```
 
 #### INVALID_TO_ZERO(*keys)
+
 TO-DO
 
 #### MAX(*values)
+
 Returns the highest number.
+
 ```ruby
 MAX(-3,-2,5)
 => 5
 ```
+
 #### MIN(*values)
+
 Returns the lowest number.
+
 ```ruby
 MIN(-3,-2,5)
 => - 3
 ```
+
 #### ABS(*values)
+
 Returns all given numbers in absolute values.
+
 ```ruby
 ABS(-3,-2,5)
 => [3,2,5]
 ```
 
 #### ROUND(value, precision = 0)
+
 Public: Rounds numeric value to a given precision.
+
 ```ruby
 ROUND(3.334,2)
 => [3.33]
 ```
 
 #### FLOOR(value, precision = 0)
+
 Returns the largest number less than or equal to numeric value.
+
 ```ruby
 FLOOR(3.5)
 => 3
 ```
 
-#### CEIV(value, precision = 0)
+#### CEIL(value, precision = 0)
+
 Returns the smallest number greater than or equal to numeric value.
+
 ```ruby
-CEIV(3.5)
+CEIL(3.5)
 => 4
 ```
 
 #### SQRT(*values)
+
 Returns the square root of the given values.
+
 ```ruby
 SQRT(4) 
 => [2]
 
 SQRT(4,9) 
 => [2,3]
-
-SUM(SQRT(4,9)) 
-=> 5
-
 ```
 
-
 #### LESS(x,y)
-Returns true when x is smaller than y.
 
-Note: This function only looks at the first two values entered in this function.
+Returns true when x is smaller than y. Note: This function only looks at the first two values entered in this function.
 
 ```ruby
 LESS(1,2) 
@@ -188,11 +216,9 @@ LESS(1,2,5)
 => true
 ```
 
-
 #### LESS_OR_EQUAL(x,y)
-Returns true when x is smaller or equal than y.
 
-Note: This function only looks at the first two values entered in this function.
+Returns true when x is smaller or equal than y. Note: This function only looks at the first two values entered in this function.
 
 ```ruby
 LESS_OR_EQUAL(1,2) 
@@ -212,9 +238,8 @@ LESS_OR_EQUAL(1,2,5)
 ```
 
 #### GREATER(x,y)
-Returns true when x is greater than y.
 
-Note: This function only looks at the first two values entered in this function.
+Returns true when x is greater than y. Note: This function only looks at the first two values entered in this function.
 
 ```ruby
 GREATER(1,2) 
@@ -231,9 +256,7 @@ GREATER(2,1,5)
 ```
 
 #### GREATER_OR_EQUAL(x,y)
-Returns true when x is smaller or equal than y.
-
-Note: This function only looks at the first two values entered in this function.
+Returns true when x is smaller or equal than y. Note: This function only looks at the first two values entered in this function.
 
 ```ruby
 GREATER_OR_EQUAL(1,2) 
@@ -253,9 +276,7 @@ GREATER_OR_EQUAL(2,1,5)
 ```
 
 #### EQUALS(x,y)
-Returns true when x is equal to y.
-
-Note: This function only looks at the first two values entered in this function.
+Returns true when x is equal to y. Note: This function only looks at the first two values entered in this function.
 
 ```ruby
 EQUALS(1,1) 
@@ -269,9 +290,7 @@ EQUALS(1,1,5)
 ```
 
 #### NOT
-Returns true when x is not equal to y.
-
-Note: This function only looks at the first two values entered in this function.
+Returns true when x is not equal to y. Note: This function only looks at the first two values entered in this function.
 
 ```ruby
 NOT(1,1) 
@@ -288,9 +307,8 @@ NOT(1,1,5)
 TO-DO
 
 #### IS_NUMBER(x)
-Returns true when x is a number.
 
-Note: The value is only recognized when placed in brackets.
+Returns true when x is a number. Note: The value is only recognized when placed in brackets.
 Furthermore it only looks at the first element inside the brackets.
 While not using brackets, the function will expect one element.
 
@@ -312,13 +330,10 @@ IS_NUMBER([3],'three')
 ```
 
 #### IS_NIL (value)
-Returns true when the given value is nil. 
-False when the value is not nil.
+Returns true when the given value is nil. False when the value is not nil.
 
 #### NEG(x)
-Returns the negative value of the given value.
-
-Note: Only the first value is taken into account.
+Returns the negative value of the given value. Note: Only the first value is taken into account.
 
 ```ruby
 NEG(1) 
@@ -332,16 +347,17 @@ NEG(-1,-2)
 ```
 
 #### UNIT(x,unit)
+
 Converts a value to another format.
+
 ```ruby
 UNIT(0.15,percentage) 
 => 15.0 (%)
 ```
 
 #### INVERSE(x)
-Returns the inverse of a given value.
+Returns the inverse of a given value. Note: Only the first value is taken into account.
 
-Note: Only the first value is taken into account.
 ```ruby
 INVERSE(5)
 => 0.2
@@ -350,9 +366,10 @@ INVERSE(5,2)
 => 0.2
 ```
 
-
 #### FLATTEN(array)
+
 Flattens any nested arrays into a single array with depth=1, removing nils
+
 ```ruby
 FLATTEN([[1],[2],[3]])
 =>
@@ -378,7 +395,9 @@ EQUALS(2,3,3)
 ```
 
 #### IF(condition, true_stmt, false_stmt)
-If the condition is true, the true_stmt is returned, if the condition is false, the false_stmt is retunred. 
+
+If the condition is true, the true_stmt is returned, if the condition is false, the false_stmt is returned.
+
 ```ruby
 IF(EQUALS(1,1),3,4) 
 => 3 --> EQUALS(1,1) returns 'true', so 3 is returned.
@@ -389,38 +408,42 @@ IF(EQUALS(1,2),3,4)
 
 ### Core functions
 
-The Core functions form the core of GQL. With these functions you can extract data from elements of the model. 
+The Core functions form the core of GQL. With these functions you can extract data from elements of the model.
 
 #### V(args)
 
-Shortcut for the LOOKUP and MAP function. Also see LOOKUP() and MAP().
-Used to retrieve information from the energy graph.
+Shortcut for the LOOKUP and MAP function. Used to retrieve information from the energy graph.
 
-Example with node
+Example with node.
+
 ```ruby
 V(foo) --> LOOKUP(foo)
 => foo
 ```
 
-Example Lookup multiple nodes by their keys
+Example Lookup multiple nodes by their keys.
+
 ```ruby
 V(foo,bar) --> LOOKUP(foo,bar)
 => [<foo>, <bar>]
 ```
 
-Example Lookup a node attribute
+Example Lookup a node attribute.
+
 ```ruby
 V(foo,demand) --> MAP(LOOKUP(foo,demand))
 => 100 (When demand of node 'foo' is equal to 100)
 ```
 
-Example nesting of LOOKUPs
+Example nesting of LOOKUPs.
+
 ```ruby
 V(V(foo), V(bar), demand) --> MAP(LOOKUP(foo, LOOKUP(bar)), demand)
 => 100, 200 
 ```
 
-Example pass objects to V()
+Example pass objects to V().
+
 ```ruby
 V(CARRIER(electricity), cost_per_mj) --> = MAP( LOOKUP(CARRIER(electricity)), cost_per_mj )
 => 23.3
@@ -434,40 +457,24 @@ Same functionalities as V, but used for the molecule graph.
 
 QUERY() or Q() returns the result of a gquery with given key.
 
-Example costs
-
 ```ruby
 Q(total_costs)
 => 100
 ```
 
-#### FILTER(collection, filter)
-Imposes a filter.
-
-Can be used to impose a filter on node groups based on node attributes, see example.
-
-Example:
-
-```ruby
-FILTER(G(electricity_production),"geothermal_input_conversion > 0.0")
-=> 
-[
-  <#Node energy_power_geothermal>,
-]
-```
-
 #### CHILDREN(*nodes)
+
 TO-DO
 
 #### PARENTS(*nodes)
+
 TO-DO
 
 #### QUERY_PRESENT(key)
-Returns the present value of the the gquery, when given a key.
 
-If the argument is a lambda ( -> { ... }), it returns the present value of the query inside the lamba.
-example:
-```
+Returns the present value of the the gquery, when given a key. If the argument is a lambda ( -> { ... }), it returns the present value of the query inside the lamba.
+
+```ruby
 GRAPH(year)
 =>
 2019      2,019
@@ -493,11 +500,9 @@ error
 
 ```
 
-
 #### QUERY_FUTURE(key)
 
-Returns the present value of the the gquery, when given a key.
-If the argument is a lambda ( -> { ... }), it returns the present value of the query inside the lamba. 
+Returns the present value of the the gquery, when given a key. If the argument is a lambda ( -> { ... }), it returns the present value of the query inside the lamba. 
 
 ```ruby
 GRAPH(year)
@@ -526,7 +531,8 @@ error
 
 #### QUERY_DELTA(key)
 
-Returns the delta of the present value and future value of the query. Note: an operation within this query should be noted inside ( -> { ... }). See examples: 
+Returns the delta of the present value and future value of the query. Note: an operation within this query should be noted inside ( -> { ... }).
+
 ```ruby
 QUERY_DELTA(graph_year)  
 => 
@@ -543,99 +549,17 @@ QUERY_DELTA(GRAPH(year))
 error
 ```
 
+#### AREA()
 
-#### ALL
-Returns an Array of all nodes in the energy graph. #Why is this necesary?
-Can also be found via the engine.
-
-#### MALL 
-Returns an Array of all nodes in the molecule graph. #Why is this necesary?
-Can also be found via the engine.
-
-#### GROUP(group)
-
-Returns an Array of all nodes for a given energy group.
-```ruby
-GROUP(apartments)
-=>
-[
-  #<Node households_useful_demand_for_space_heating_apartments_1945_1964>,
-  #<Node households_useful_demand_for_space_heating_apartments_1965_1984>,
-  #<Node households_useful_demand_for_space_heating_apartments_1985_2004>,
-  #<Node households_useful_demand_for_space_heating_apartments_2005_present>,
-  #<Node households_useful_demand_for_space_heating_apartments_before_1945>,
-  #<Node households_useful_demand_for_space_heating_apartments_future>,
-]
-```
-#### MGROUP(group)
-Returns an Array of all nodes for a given molecule group.
-```ruby
-MGROUP(ccu_emitted)
-
-[
-  #<Node molecules_production_synthetic_methanol_emitted_co2>,
-]
-```
-
-#### EDGE_GROUP(group)
-TO-DO
-
-#### MEDGE_GROUP
-TO-DO
-
-#### SECTOR(sector)
-
-Returns an Array of nodes for a given energy sector
-
-```ruby
-###SECTOR(households)
-=>
-[
-  #<Node households_apartments_useful_demand_for_space_heating>,
-  #<Node households_apartments_useful_demand_for_space_heating_after_insulation>,
-...
-]
-```
-
-#### MSECTOR
-
-Returns an Array of nodes for a given molecule sector
-
-```ruby
-SECTOR(energy)
-=>
-[
-  #<Node energy_chp_supercritical_ccs_ht_waste_mix_captured_co2>,
-  #<Node energy_chp_supercritical_ccs_ht_waste_mix_co2>,
-...
-]
-```
-
-#### CARRIER(key)
-Returns an Array of carriers for given key(s). Returns carriers belonging to the energy graph.
-#### Could use some more details on why this is useful.
-
-```ruby
-CARRIER(electricity)
-=>
-[
-  <Qernel::Carrier id:electricity key:electricity>,
-]
-```
-
-#### MCARRIER
-Returns an Array of carriers for given key(s). Returns carriers belonging to the molecule graph. See CARRIER
-
-#### AREA
 Returns an attribute.
 
-Example:
 ```ruby
 AREA(present_number_of_residences) 
 => 7349500.0
 ```
 
 #### LAST(values)
+
 Returns the last element of the array.
 
 ```ruby
@@ -645,8 +569,8 @@ LAST(V(1,2,3))
 ```
 
 #### FIRST(values)
+
 Returns the first element of the array.
-Example:
 ```ruby
 LAST(V(1,2,3))
 =>
@@ -655,7 +579,8 @@ LAST(V(1,2,3))
 
 #### EDGE(lft,rgt)
 
-Returns the edge that goes from the first (lft) to the second node (rgt) for the energy graph. 
+Returns the edge that goes from the first (lft) to the second node (rgt) for the energy graph.
+
 ```ruby
 EDGE(energy_import_electricity,energy_interconnector_1_imported_electricity
 )
@@ -668,9 +593,10 @@ EDGE(energy_import_electricity,energy_interconnector_1_imported_electricity
 Returns the edge that goes from the  first (lft) to the second node (rgt) for the molecule graph. See EDGE() for functionality
 
 
-#### EDGES
+#### EDGES()
 
 Retrieves edges based on given node(s) and optional arguments to filter or specify the type of edges.
+
 ```ruby
 EDGES(V(foo))
 =>
@@ -691,8 +617,10 @@ EDGES(V(foo, bar))
 [Edges of multiple nodes]
 ```
 
-#### OUTPUT_SLOTS
+#### OUTPUT_SLOTS()
+
 Gets the output (to the left) slots of node(s). Can specify a particular type of slot or retrieve all output slots.
+
 ```ruby
 OUTPUT_SLOTS(foo)
 =>
@@ -711,10 +639,9 @@ OUTPUT_SLOTS(foo, loss)
 [(loss)-foo]
 ```
 
-#### INPUT_SLOTS
+#### INPUT_SLOTS()
 
 Gets the input (to the right) slots of node(s). Can specify a particular type of slot or retrieve all input slots.
-Examples:
 
 ```ruby
 INPUT_SLOTS(foo)
@@ -726,10 +653,10 @@ INPUT_SLOTS(foo, gas)
 [foo-(gas)]
 ```
 
-#### INPUT_EDGES
-INPUT_EDGES(value_terms, arguments = nil)
+#### INPUT_EDGES()
+
 Retrieves input edges based on given node(s) and optional arguments to filter or specify the type of edges.
-Examples:
+
 ```ruby
 INPUT_EDGES(V(foo))
 =>
@@ -750,8 +677,10 @@ INPUT_EDGES(V(foo, bar))
 [Input edges of multiple nodes]
 ```
 
-#### OUTPUT_EDGES
+#### OUTPUT_EDGES()
+
 Retrieves output edges based on given node(s) and optional arguments to filter or specify the type of edges.
+
 ```ruby
 OUTPUT_EDGES(V(foo))
 =>
@@ -780,7 +709,6 @@ With these functions you can perform operations with curves from the merit or fe
 
 Restricts the values in a curve to be between the minimum and maximum. Raises an error if min > max.
 
-Example:
 ```ruby
 CLAMP_CURVE([1,2,3,4],0,2)
 => [1,2,2,2]
@@ -793,7 +721,6 @@ CLAMP_CURVE([1,-2,3,-4],0,2)
 
 If the given `curve` is an array of non-zero length, it is returned. If the curve is nil or empty, a new curve of `length` length is created, with each value set to `default`.
 
-Example with 'nil':
 ```ruby
 COALESCE_CURVE(nil,3,5)
 => [3,3,3,3,3]
@@ -807,7 +734,6 @@ Since no values are given for default & length, these are set to 0 & 8760 respec
 #### CUMULATIVE_CURVE(curve)
 
 Creates a new curve where each index (n) is the sum of (0..n) in the source curve.
-Example:
 
 ```ruby
 CUMULATIVE_CURVE([1, 2,3,4])
@@ -821,7 +747,6 @@ CUMULATIVE_CURVE([1,-2,3,-4])
 #### INVERT_CURVE(curve)
 
 Inverts a single curve by swapping positive numbers to be negative, and vice-versa.
-Example:
 
 ```ruby
 INVERT_CURVE([1, 2,3,4])
@@ -833,10 +758,8 @@ INVERT_CURVE([1,-2,3,-4])
 
 
 #### SUM_CURVES(*curves)
+
 Adds the values in multiple curves.
-
-
-Example:
 
 ```ruby
 SUM_CURVES([1, 2], [3, 4])
@@ -847,26 +770,23 @@ SUM_CURVES([[1, 2], [3, 4]])
 ```
 
 #### PRODUCT_CURVES(left,right)
-Multiplies two curves elementwise.
-Note that unlike `SUM_CURVES`, `PRODUCT_CURVES` expects exactly two arguments, each one a curve.
-An error will be raised if either parameter is an array of curves, or if the curves don't have matching lengths.
+Multiplies two curves elementwise. Note that unlike `SUM_CURVES`, `PRODUCT_CURVES` expects exactly two arguments, each one a curve. An error will be raised if either parameter is an array of curves, or if the curves don't have matching lengths.
 
-Example:
 ```ruby
 PRODUCT_CURVES([1, 2, 3], [4, 5, 6])
 => [4, 10, 18]
 ```
 
 #### DIVIDE_CURVES(left, right)
-Divides two curves elementwise.
-Note that unlike `SUM_CURVES`, `PRODUCT_CURVES` expects exactly two arguments, each one a curve.
-An error will be raised if either parameter is an array of curves, or if the curves don't have matching lengths.
+Divides two curves elementwise. Note that unlike `SUM_CURVES`, `DIVIDE_CURVES` expects exactly two arguments, each one a curve. An error will be raised if either parameter is an array of curves, or if the curves don't have matching lengths.
+
 ```ruby
 DIVIDE_CURVES([1, 2, 3], [4, 5, 6])
 => [0.25, 0.4, 0.5]
 ```
 
 #### SMOOTH_CURVE(curve, window_size)
+
 Creates a smoothed curve using a moving average.
 curve       - An array of numbers.
 window_size - The number of points to average over.
@@ -876,12 +796,9 @@ window_size - The number of points to average over.
 These functions can support the user in gaining a quick insight in the data. See the examples below for use cases of these functions.
 
 #### SORT_BY(*objects, arguments)
-With SORT_BY nodes can be sorted on one of their attributes.
-The nodes will be sorted ascending to the value of the attribute.
-Ranking of the nodes will start from 0.
-Note that the value of the attribute will not be printed, see TXT_TABLE for this functionality.
 
-Example with the group 'useful_demand'.
+With SORT_BY nodes can be sorted on one of their attributes. The nodes will be sorted ascending to the value of the attribute. Ranking of the nodes will start from 0. Note that the value of the attribute will not be printed, see TXT_TABLE for this functionality.
+
 ```ruby
 SORT_BY(G(useful_demand),demand)
 => 
@@ -894,8 +811,8 @@ SORT_BY(G(useful_demand),demand)
 
 
 #### TXT_TABLE(objects, *argyments)
-With TXT_TABLE 1 or more attributes from a node group can be queried.
-The nodes in the given node group will be sorted alphabetically.
+
+With TXT_TABLE 1 or more attributes from a node group can be queried. The nodes in the given node group will be sorted alphabetically.
 
 Within the GQL-sandbox users can choose how the view the table in 4 different modes:
 * Table: Shows the table in standard GQL-sandbox format.
@@ -936,9 +853,10 @@ TXT_TABLE(SORT_BY(G(useful_demand),demand),key,demand)
 | industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic       | 2650973321780.0    |
 +------------------------------------------------------------------------------+--------------------+
 ```
-#### EACH
+#### EACH()
+
 Lets the user run multiple queries.
-Example:
+
 ```ruby
 EACH(
   SUM(foo, ...),
@@ -950,10 +868,98 @@ EACH(
 ```
 
 ### Set functions
+
 These functions concern operations associated with graph theory.
 
+#### ALL()
+Returns an Array of all nodes in the energy graph.
+
+#### MALL()
+Returns an Array of all nodes in the molecule graph.
+
+#### GROUP(group)
+
+Returns an Array of all nodes for a given energy group.
+
+```ruby
+GROUP(apartments)
+=>
+[
+  #<Node households_useful_demand_for_space_heating_apartments_1945_1964>,
+  #<Node households_useful_demand_for_space_heating_apartments_1965_1984>,
+  #<Node households_useful_demand_for_space_heating_apartments_1985_2004>,
+  #<Node households_useful_demand_for_space_heating_apartments_2005_present>,
+  #<Node households_useful_demand_for_space_heating_apartments_before_1945>,
+  #<Node households_useful_demand_for_space_heating_apartments_future>,
+]
+```
+
+#### MGROUP(group)
+
+Returns an Array of all nodes for a given molecule group.
+
+```ruby
+MGROUP(ccu_emitted)
+
+[
+  #<Node molecules_production_synthetic_methanol_emitted_co2>,
+]
+```
+
+#### EDGE_GROUP(group)
+
+TO-DO
+
+#### MEDGE_GROUP(group)
+
+TO-DO
+
+#### SECTOR(sector)
+
+Returns an Array of nodes for a given energy sector.
+
+```ruby
+###SECTOR(households)
+=>
+[
+  #<Node households_apartments_useful_demand_for_space_heating>,
+  #<Node households_apartments_useful_demand_for_space_heating_after_insulation>,
+...
+]
+```
+
+#### MSECTOR(sector)
+
+Returns an Array of nodes for a given molecule sector.
+
+```ruby
+SECTOR(energy)
+=>
+[
+  #<Node energy_chp_supercritical_ccs_ht_waste_mix_captured_co2>,
+  #<Node energy_chp_supercritical_ccs_ht_waste_mix_co2>,
+...
+]
+```
+
+#### CARRIER(key)
+
+Returns an Array of carriers for given key(s). Returns carriers belonging to the energy graph.
+
+```ruby
+CARRIER(electricity)
+=>
+[
+  <Qernel::Carrier id:electricity key:electricity>,
+]
+```
+
+#### MCARRIER()
+
+Returns an Array of carriers for given key(s). Returns carriers belonging to the molecule graph. See CARRIER.
 
 #### INTERSECTION(*keys)
+
 Returns the elements that are present in both the first and second arrays.
 
 ```ruby
@@ -962,12 +968,25 @@ INTERSECTION( V(1,2,3) , V(2,3,4) )
 ```
 
 #### EXCLUDE(*keys)
+
 Returns an Array of elements of the first array excluding the second array.
+
 ```ruby
 EXCLUDE( V(1,2,3) , V(2,3,4) )
 => [1]
 ```
 
+#### FILTER(collection, filter)
+
+Imposes a filter. Can be used to impose a filter on node groups based on node attributes, see example.
+
+```ruby
+FILTER(G(electricity_production),"geothermal_input_conversion > 0.0")
+=> 
+[
+  <#Node energy_power_geothermal>,
+]
+```
 
 ### Fever functions
 
@@ -990,12 +1009,12 @@ TO-DO
 TO-DO
 
 ### Update functions
+
 These functions concern operations used to update values in the model.
 
+#### UPDATE()
 
-#### UPDATE
-Updates attributes or elements based on the specified conditions or inputs, with various strategies (absolute, relative_total, or relative_per_year).
-Can be combined with the UPDATE function.
+Updates attributes or elements based on the specified conditions or inputs, with various strategies (absolute, relative_total, or relative_per_year). Can be cobmined with the `EACH` function.
 
 ```ruby
 UPDATE(V(foo), demand, 100)
@@ -1015,9 +1034,10 @@ EACH(
 
 
 ```
-#### UPDATE_WITH_FACTOR
-Same as UPDATE, but the input value is expected to be a factor that the user supplies.
-Example:
+
+#### UPDATE_WITH_FACTOR()
+Same as `UPDATE`, but the input value is expected to be a factor that the user supplies.
+
 ```ruby
 UPDATE_WITH_FACTOR(V(foo), preset_demand, 1.1)
 =>
@@ -1025,9 +1045,10 @@ Foo gets a demand of 110.0
 
 ```
 
-#### UPDATE_ABSOLUTE
-Same as UPDATE, but forcefully behaving as the absolute strategy.
-Example:
+#### UPDATE_ABSOLUTE()
+
+Same as `UPDATE`, but forcefully behaving as the absolute strategy.
+
 ```ruby
 UPDATE_ABSOLUTE(V(foo), demand, 500)
 =>
@@ -1035,9 +1056,10 @@ Demand of foo becomes 500
 
 ```
 
-#### USER_INPUT
+#### USER_INPUT()
+
 Retrieves the numeric value of the user input, handling different formats (absolute, percentage, etc.).
-Example:
+
 ```ruby
 USER_INPUT()
 =>
@@ -1045,8 +1067,9 @@ USER_INPUT()
 ```
 
 #### INPUT_VALUE(key)
+
 Retrieves the value of a specified input.
-Example:
+
 ```ruby
 INPUT_VALUE('agriculture_geothermal_share')
 =>

--- a/docs/contrib/gql.md
+++ b/docs/contrib/gql.md
@@ -1,6 +1,9 @@
 ---
 title: Graph Query Language (GQL)
 ---
+
+
+
 # General information GQL
 
 GQL is used to calculate values that are used in the graphs, tables and figures that can be viewed in the model. Users can check values themselves by using the GQL-sandbox in ETEngine. This can be found here --> [Link]
@@ -11,9 +14,51 @@ Please note that the output that is printed in this documentation is dependent o
 GQL is case sensitive. Since all GQL-functions are written in caps, this means that all functions **must** be written in caps in order to function.
 
 
-List of all functions:
+##  Constants:
 
-# Aggregate:
+### MWH_TO_GJ = 3.6
+
+### HOURS_PER_YEAR = 8760.0
+
+### MAN_HOURS_PER_MAN_YEAR = 1800.0
+
+### MAN_YEAR_PER_MJ_INSULATION_PER_YEAR = 0.0000000122916
+
+### SECS_PER_HOUR = 3600.0
+
+### SECS_PER_YEAR = SECS_PER_HOUR * HOURS_PER_YEAR
+
+### KG_PER_TONNE = 1000
+
+### LITER_PER_BARREL = 159
+
+### MJ_TO_MHW = 3600
+
+### MJ_PER_KWH = 3.6
+
+### MJ_PER_MWH = 3600
+
+### BILLIONS = 10.0**9
+
+### MJ_TO_PJ = BILLIONS
+
+### MILLIONS = 10.0**6
+
+### THOUSANDS = 1000.0
+
+### #NIL = nil if !defined?(NIL)
+
+### EURO_SIGN = '&euro;'
+
+### MONTHS_PER_YEAR = 12.0
+
+### INFINITY = Float::INFINITY
+
+
+# List of all functions:
+
+
+## Functions to be categorized
 
 ### COUNT(values)
 
@@ -74,7 +119,7 @@ AVG(1,nil,nil,2)
 => 1.5
 ```
 
-SUM
+### SUM
 Returns the sum of all numbers (ignores nil values).
 ```
 SUM(1,2) 
@@ -98,7 +143,7 @@ PRODUCT(1,nil)
 
 ### DIVIDE(values)
 
-Divides the first with the second.
+Divides the first value with the second value.
 ```
 DIVIDE(1,2)
 => 0.5
@@ -107,54 +152,13 @@ DIVIDE(1,2,3,4)
 => 0.5 --> only takes the second.
 ```
 
-Constants:
-
-MWH_TO_GJ = 3.6
-
-HOURS_PER_YEAR = 8760.0
-
-MAN_HOURS_PER_MAN_YEAR = 1800.0
-
-MAN_YEAR_PER_MJ_INSULATION_PER_YEAR = 0.0000000122916
-
-SECS_PER_HOUR = 3600.0
-
-SECS_PER_YEAR = SECS_PER_HOUR * HOURS_PER_YEAR
-
-KG_PER_TONNE = 1000
-
-LITER_PER_BARREL = 159
-
-MJ_TO_MHW = 3600
-
-MJ_PER_KWH = 3.6
-
-MJ_PER_MWH = 3600
-
-BILLIONS = 10.0**9
-
-MJ_TO_PJ = BILLIONS
-
-MILLIONS = 10.0**6
-
-THOUSANDS = 1000.0
-
-#NIL = nil if !defined?(NIL)
-
-EURO_SIGN = '&euro;'
-
-MONTHS_PER_YEAR = 12.0
-
-INFINITY = Float::INFINITY
-
-# Control
 
 
 
 
 ### EQUALS(values)
 
-Checks if the **first two** values are given are equal.
+Checks if the **first two** values that are given are equal.
 
 ```
 EQUALS(2,2)
@@ -171,7 +175,7 @@ EQUALS(2,3,3)
 ```
 
 ### IF(condition, true_stmt, false_stmt)
-If the condition is true, the true_stmt is given, if the condition is false, the false_stmt is given. 
+If the condition is true, the true_stmt is returned, if the condition is false, the false_stmt is retunred. 
 ```
 IF(EQUALS(1,1),3,4) 
 => 3 --> EQUALS(1,1) returns 'true', so 3 is returned.
@@ -180,11 +184,12 @@ IF(EQUALS(1,2),3,4)
 => 4 --> EQUALS(1,2) returns 'false', so 4 is returned.
 ```
 
-# Core
+
 
 ### V(args)
 
-Shortcup for the LOOKUP and MAP function. Also see {#LOOKUP} and {#MAP}.
+Shortcut for the LOOKUP and MAP function. Also see LOOKUP() and MAP().
+Used to retrieve information from the energy graph.
 
 Example with node
 ```
@@ -225,7 +230,7 @@ Same functionalities as V, but used for the molecule graph.
 
 ### Q(key)
 
-QUERY() or Q() returns the result of another gquery with given key.
+QUERY() or Q() returns the result of a gquery with given key.
 
 Example costs
 
@@ -289,6 +294,7 @@ Lookup or L for the moleculegraph, alias for ML.
 Access attributes of one or more objects.
 
 === Single and composed attributes
+
 To query a single attribute simply pass it. You can put it inside '', "" or not.
 
 To join multiple attributes and numbers surround it with "" or ''.
@@ -320,7 +326,7 @@ MAP(L(foo), 'demand * (3.0 + free_co2_factor)')
 ```
 MAP(L(foo), primary_demand_of(CARRIER(electricity)))
 ```
- ### TODO
+
 
 ### M(elements,attr_name)
 
@@ -328,10 +334,9 @@ ALIAS for MAP
 
 ### GET(keys)
 
-Retrieves the attribute from one *single* object and is therefore similar to MAP.
+Retrieves the attribute from one single object, similar to MAP.
 
 
-# Curves
 
 ### ATTACHED_CURVE(name)
 
@@ -393,22 +398,9 @@ Creates a smoothed curve using a moving average.
 curve       - An array of numbers.
 window_size - The number of points to average over.
 
-# Helper
-
-### OBSERVE_SET(objects, arguments)
-
-OBSERVE_SET is mainly used to observe the graph calculation.
-It may be extended for more use. Observing update statements is done
-using Update#update_element_with in the debug runtime. 
-#### Might not be interesting for user.
 
 
-#### OBSERVE_GET(objects, arguments)
-
-#### todo
-#### Might not be interesting for user.
-
-#### SORT_BY(*objects, arguments)
+### SORT_BY(*objects, arguments)
 With SORT_BY nodes can be sorted on one of their attributes.
 The nodes will be sorted ascending to the value of the attribute.
 Ranking of the nodes will start from 0.
@@ -426,7 +418,7 @@ SORT_BY(G(useful_demand),demand)
 ```
 
 
-#### TXT_TABLE(objects, *argyments)
+### TXT_TABLE(objects, *argyments)
 With TXT_TABLE 1 or more attributes from a node group can be queried.
 The nodes in the given node group will be sorted alphabetically.
 
@@ -470,13 +462,12 @@ TXT_TABLE(SORT_BY(G(useful_demand),demand),key,demand)
 +------------------------------------------------------------------------------+--------------------+
 ```
 
-#### EXCEL_TABLE(objects, *arguments)
+### EXCEL_TABLE(objects, *arguments)
 Similar functionality to TXT_TABLE
 
 
-# Legacy
 
-#### FILTER(collection, filter)
+### FILTER(collection, filter)
 Imposes a filter.
 
 Can be used to impose a filter on node groups based on node attributes, see example.
@@ -491,13 +482,13 @@ FILTER(G(electricity_production),"geothermal_input_conversion > 0.0")
 ]
 ```
 
-#### CHILDREN(*nodes)
-#### Todo
+### CHILDREN(*nodes)
+todo
 
-#### PARENTS(*nodes)
-#### Todo
+### PARENTS(*nodes)
+todo
 
-#### INTERSECTION(*keys)
+### INTERSECTION(*keys)
 Returns the elements that are present in both the first and second arrays.
 
 ```
@@ -505,50 +496,56 @@ INTERSECTION( V(1,2,3) , V(2,3,4) )
 => [2, 3]
 ```
 
-#### EXCLUDE(*keys)
+### EXCLUDE(*keys)
 Returns an Array of elements of the first array excluding the second array.
 ```
 EXCLUDE( V(1,2,3) , V(2,3,4) )
 => [1]
 ```
-#### INVALID_TO_ZERO(*keys)
+### INVALID_TO_ZERO(*keys)
 Deprecated?
 
-#### MAX(*values)
+### MAX(*values)
 Returns the highest number.
 ```
 MAX(-3,-2,5)
 => 5
 ```
-#### MIN(*values)
+### MIN(*values)
 Returns the lowest number.
 ```
 MIN(-3,-2,5)
 => - 3
 ```
-#### ABS(*values)
+### ABS(*values)
 Returns all given numbers in absolute values.
 ```
 ABS(-3,-2,5)
 => [3,2,5]
 ```
 
-#### ROUND(value, precision = 0)
+### ROUND(value, precision = 0)
 Public: Rounds numeric value to a given precision.
 ```
 ROUND(3.334,2)
 => [3.33]
 ```
 
-#### FLOOR(value, precision = 0)
+### FLOOR(value, precision = 0)
 Returns the largest number less than or equal to numeric value.
-#### Todo
+```
+FLOOR(3.5)
+=> 3
+```
 
-#### CEIL(value, precision = 0)
+### CEIL(value, precision = 0)
 Returns the smallest number greater than or equal to numeric value.
-#### Todo
+```
+CEIL(3.5)
+=> 4
+```
 
-#### SQRT(*values)
+### SQRT(*values)
 Returns the square root of the given values.
 ```
 SQRT(4) 
@@ -561,9 +558,10 @@ SUM(SQRT(4,9))
 => 5
 ```
 
-#### LESS(x,y)
+### LESS(x,y)
 Returns true when x is smaller than y.
-Note: This function only looks at the first two numbers entered in this function.
+
+Note: This function only looks at the first two values entered in this function.
 
 ```
 LESS(1,2) 
@@ -580,9 +578,10 @@ LESS(1,2,5)
 ```
 
 
-#### LESS_OR_EQUAL(x,y)
+### LESS_OR_EQUAL(x,y)
 Returns true when x is smaller or equal than y.
-Note: This function only looks at the first two numbers entered in this function.
+
+Note: This function only looks at the first two values entered in this function.
 
 ```
 LESS_OR_EQUAL(1,2) 
@@ -601,9 +600,10 @@ LESS_OR_EQUAL(1,2,5)
 => true
 ```
 
-#### GREATER(x,y)
+### GREATER(x,y)
 Returns true when x is greater than y.
-Note: This function only looks at the first two numbers entered in this function.
+
+Note: This function only looks at the first two values entered in this function.
 
 ```
 GREATER(1,2) 
@@ -619,9 +619,10 @@ GREATER(2,1,5)
 => true
 ```
 
-#### GREATER_OR_EQUAL(x,y)
+### GREATER_OR_EQUAL(x,y)
 Returns true when x is smaller or equal than y.
-Note: This function only looks at the first two numbers entered in this function.
+
+Note: This function only looks at the first two values entered in this function.
 
 ```
 GREATER_OR_EQUAL(1,2) 
@@ -640,9 +641,10 @@ GREATER_OR_EQUAL(2,1,5)
 => true
 ```
 
-#### EQUALS(x,y)
+### EQUALS(x,y)
 Returns true when x is equal to y.
-Note: This function only looks at the first two numbers entered in this function.
+
+Note: This function only looks at the first two values entered in this function.
 
 ```
 EQUALS(1,1) 
@@ -655,9 +657,10 @@ EQUALS(1,1,5)
 => true
 ```
 
-#### NOT
+### NOT
 Returns true when x is not equal to y.
-Note: This function only looks at the first two numbers entered in this function.
+
+Note: This function only looks at the first two values entered in this function.
 
 ```
 NOT(1,1) 
@@ -670,12 +673,13 @@ NOT(1,1,5)
 => false
 ```
 
-#### OR
-#### TODO
+### OR
+todo
 
-#### IS_NUMBER(x)
+### IS_NUMBER(x)
 Returns true when x is a number.
-Note: The number is only recognized when placed in brackets.
+
+Note: The value is only recognized when placed in brackets.
 Furthermore it only looks at the first element inside the brackets.
 While not using brackets, the function will expect one element.
 
@@ -696,147 +700,552 @@ IS_NUMBER([3],'three')
 => Error: Wrong number of elements
 ```
 
-#### IS_NIL
-#### TODO
-Don't know a good true use case for this.
+### IS_NIL (value)
+Returns true when the given value is nil. 
+False when the value is not nil.
 
-#### NEG(x)
-Returns the first value but negative.
+### NEG(x)
+Returns the negative value of the given value.
+
+Note: Only the first value is taken into account.
 
 ```
-NEG(5) 
-=> 5
+NEG(1) 
+=> -1
 
-NEG(5) 
-=> -5
-#### UNIT
+NEG(1,2)
+=> -1
 
-#### INVERSE
+NEG(-1,-2)
+=> 1
+```
 
-#### FLATTEN
+### UNIT(x,unit)
+Converts a value to another format.
+```
+UNIT(0.15,percentage) 
+=> 15.0 (%)
+```
 
-#### flatten_compact
+### INVERSE(x)
+Returns the inverse of a given value.
 
-#### flatten_uniq
+Note: Only the first value is taken into account.
+```
+INVERSE(5)
+=> 0.2
 
-# Lookup
+INVERSE(5,2)
+=> 0.2
+```
 
-QUERY_PRESENT
 
-QUERY_FUTURE
+### FLATTEN(array)
+Flattens any nested arrays into a single array with depth=1, removing nils
+```
+FLATTEN([[1],[2],[3]])
+=>
+[1,2,3]
+```
 
-QUERY_DELTA
 
-MIXED
+### flatten_compact(array)
+Same functionality as FLATTEN
 
-GRAPH
+### flatten_uniq(array)
+Same functionality as FLATTEN, removes duplicate values.
+```
+FLATTEN([[1],[2],[3]])
+=>
+[1,2,3]
 
-ALL
+FLATTEN([[1],[1],[3]])
+=>
+[1,3]
 
-GROUP
+```
 
-MGROUP
 
-EDGE_GROUP
 
-MEDGE_GROUP
+### QUERY_PRESENT(key)
+Returns the present value of the the gquery, when given a key.
 
-SECTOR
+If the argument is a lambda ( -> { ... }), it returns the present value of the query inside the lamba.
+example:
+```
+GRAPH(year)
+=>
+2019      2,019
+2050      2,050
 
-MSECTOR
+Q(graph_year)
+=>
+2019      2,019
+2050      2,050
 
-USE
 
-CARRIER
+QUERY_PRESENT(graph_year)  
+=>
+2,019
 
-MCARRIER
+QUERY_PRESENT( -> { GRAPH(year) } )   
+=> 
+2,019
 
-AREA
+QUERY_PRESENT(GRAPH(year))   
+=> 
+error
 
-INSULATION_COST
+```
 
-WEATHER_PROPERTY
 
-FEVER_DEMAND
+### QUERY_FUTURE(key)
 
-FEVER_PRODUCTION
+Returns the present value of the the gquery, when given a key.
+If the argument is a lambda ( -> { ... }), it returns the present value of the query inside the lamba. 
 
-CURVE_SET_VARIANTS
+```
+GRAPH(year)
+=>
+2019      2,019
+2050      2,050
 
-GOAL
+Q(graph_year)
+=>
+2019      2,019
+2050      2,050
 
-GOAL_IS_SET
 
-GOAL_USER_VALUE
+QUERY_FUTURE(graph_year)  
+=>
+2,019
 
-ELEMENT_AT
+QUERY_FUTURE( -> { GRAPH(year) } )   
+=> 
+2,019
 
-LAST
+QUERY_FUTURE(GRAPH(year))   
+=> 
+error
+```
 
-FIRST
+### QUERY_DELTA(key)
 
-EDGE
+Returns the delta of the present value and future value of the query. Note: an operation within this query should be noted inside ( -> { ... }). See examples: 
+```
+QUERY_DELTA(graph_year)  
+=> 
+2019: 0.0
+2050 : 31
 
-MEDGE
+QUERY_DELTA( -> { GRAPH(year) } )   
+=> 
+2019: 0.0
+2050 : 31
 
-EDGES
+QUERY_DELTA(GRAPH(year))
+=>
+error
+```
 
-OUTPUT_SLOTS
+### MIXED
+TODO
 
-INPUT_SLOTS
 
-INPUT_EDGES
+### GRAPH(keys)
+Returns an attribute of a graph:
+keys - the name of the attribute.
+```
+GRAPH(year)
+=>
+2019      2,019
+2050      2,050
+```
 
-OUTPUT_EDGES
+### ALL
+Returns an Array of all nodes in the energy graph. #Why is this necesary?
+Can also be found via the engine.
 
-edges_for
+### MALL 
+Returns an Array of all nodes in the molecule graph. #Why is this necesary?
+Can also be found via the engine.
 
-edge_between_nodes
+### GROUP(group)
 
-# Update
+Returns an Array of all nodes for a given energy group.
+```
+GROUP(apartments)
+=>
+[
+  #<Node households_useful_demand_for_space_heating_apartments_1945_1964>,
+  #<Node households_useful_demand_for_space_heating_apartments_1965_1984>,
+  #<Node households_useful_demand_for_space_heating_apartments_1985_2004>,
+  #<Node households_useful_demand_for_space_heating_apartments_2005_present>,
+  #<Node households_useful_demand_for_space_heating_apartments_before_1945>,
+  #<Node households_useful_demand_for_space_heating_apartments_future>,
+]
+```
+### MGROUP(group)
+Returns an Array of all nodes for a given molecule group.
+```
+MGROUP(ccu_emitted)
 
-EACH
+[
+  #<Node molecules_production_synthetic_methanol_emitted_co2>,
+]
+```
 
-UPDATE
+### EDGE_GROUP(group)
+Deprecated?
 
-UPDATE_WITH_FACTOR
+### MEDGE_GROUP
+Deprecated?
 
-UPDATE_ABSOLUTE
+### SECTOR(sector)
 
-update_something_by
+Returns an Array of nodes for a given energy sector
 
-update_element_with
+```
+###SECTOR(households)
+=>
+[
+  #<Node households_apartments_useful_demand_for_space_heating>,
+  #<Node households_apartments_useful_demand_for_space_heating_after_insulation>,
+...
+]
+```
 
-USER_INPUT
+### MSECTOR
 
-# Graph Query Language
+Returns an Array of nodes for a given molecule sector
+
+```
+SECTOR(energy)
+=>
+[
+  #<Node energy_chp_supercritical_ccs_ht_waste_mix_captured_co2>,
+  #<Node energy_chp_supercritical_ccs_ht_waste_mix_co2>,
+...
+]
+```
+
+### USE(key)
+
+Returns an Array of nodes for given energy use
+
+```
+USE(energetic)
+[
+  #<Node agriculture_burner_crude_oil>,
+  #<Node agriculture_burner_hydrogen>,
+...
+]
+```
+
+
+### CARRIER(key)
+Returns an Array of carriers for given key(s). Returns carriers belonging to the energy graph.
+### Could use some more details on why this is useful.
+
+```
+CARRIER(electricity)
+=>
+[
+  <Qernel::Carrier id:electricity key:electricity>,
+]
+```
+
+### MCARRIER
+Returns an Array of carriers for given key(s). Returns carriers belonging to the molecule graph. See CARRIER
+
+### AREA
+Returns an attribute.
+
+Example:
+```
+AREA(present_number_of_residences) 
+=> 7349500.0
+```
+
+
+### INSULATION_COST
+TODO; deprecated?
+
+### WEATHER_PROPERTY
+deprecated?
+
+### FEVER_DEMAND
+Useful?
+
+### FEVER_PRODUCTION
+Useful?
+
+### CURVE_SET_VARIANTS
+
+### GOAL
+Deprecated?
+
+### GOAL_IS_SET
+Deprecated?
+### GOAL_USER_VALUE
+Deprecated?
+
+
+### ELEMENT_AT
+Deprecated
+
+### LAST(values)
+Returns the last element of the array.
+
+```
+LAST(V(1,2,3))
+=>
+3
+```
+
+### FIRST(values)
+Returns the first element of the array.
+Example:
+```
+LAST(V(1,2,3))
+=>
+1
+```
+
+### EDGE(lft,rgt)
+
+Returns the edge that goes from the first (lft) to the second node (rgt) for the energy graph. 
+```
+EDGE(energy_import_electricity,energy_interconnector_1_imported_electricity
+)
+=>
+#<Qernel::Edge "energy_import_electricity-energy_interconnector_1_imported_electricity@imported_electricity">
+```
+
+### MEDGE(lft,rgt)
+
+Returns the edge that goes from the  first (lft) to the second node (rgt) for the molecule graph. See EDGE() for functionality
+
+
+### EDGES
+
+Retrieves edges based on given node(s) and optional arguments to filter or specify the type of edges.
+```
+EDGES(L(foo))
+=>
+[foo->gas_1, foo->gas_2, loss1->foo, heat1->foo]
+
+EDGES(L(foo), "share?")
+EDGES(L(foo), "flexible?")
+EDGES(L(foo), "flexible? && share >= 1.0")
+=>
+[Edges based on specified constraints]
+
+EDGES(OUTPUT_SLOTS(foo, heat))
+=>
+[heat->foo]
+
+EDGES(L(foo, bar))
+=>
+[Edges of multiple nodes]
+```
+
+### OUTPUT_SLOTS
+Gets the output (to the left) slots of node(s). Can specify a particular type of slot or retrieve all output slots.
+```
+OUTPUT_SLOTS(foo)
+=>
+[(loss)-foo, (heat)-foo]
+
+OUTPUT_SLOTS(L(foo))
+=>
+[(loss)-foo, (heat)-foo]
+
+OUTPUT_SLOTS(L(foo, bar))
+=>
+[(loss)-foo, (heat)-foo, ...]
+
+OUTPUT_SLOTS(foo, loss)
+=>
+[(loss)-foo]
+```
+
+### INPUT_SLOTS
+
+Gets the input (to the right) slots of node(s). Can specify a particular type of slot or retrieve all input slots.
+Examples:
+
+```
+INPUT_SLOTS(foo)
+=>
+[foo-(gas), foo-(oil)]
+
+INPUT_SLOTS(foo, gas)
+=>
+[foo-(gas)]
+```
+
+### INPUT_EDGES
+INPUT_EDGES(value_terms, arguments = nil)
+Retrieves input edges based on given node(s) and optional arguments to filter or specify the type of edges.
+Examples:
+```
+INPUT_EDGES(L(foo))
+=>
+[All input edges of node 'foo']
+
+INPUT_EDGES(L(foo), "share?")
+INPUT_EDGES(L(foo), "flexible?")
+INPUT_EDGES(L(foo), "flexible? && share >= 1.0")
+=>
+[Input edges based on specified constraints]
+
+INPUT_EDGES(INPUT_SLOTS(foo, oil))
+=>
+[foo->oil_1]
+
+INPUT_EDGES(L(foo, bar))
+=>
+[Input edges of multiple nodes]
+```
+
+### OUTPUT_EDGES
+Retrieves output edges based on given node(s) and optional arguments to filter or specify the type of edges.
+```
+OUTPUT_EDGES(L(foo))
+=>
+[All output edges of node 'foo']
+
+OUTPUT_EDGES(L(foo), "share?")
+OUTPUT_EDGES(L(foo), "flexible?")
+OUTPUT_EDGES(L(foo), "flexible? && share >= 1.0")
+=>
+[Output edges based on specified constraints]
+
+OUTPUT_EDGES(OUTPUT_SLOTS(foo, heat))
+=>
+[heat->foo]
+
+OUTPUT_EDGES(L(foo, bar))
+=>
+[Output edges of multiple nodes]
+```
+
+
+
+### EACH
+Runs multiple (update) queries.
+Example:
+```
+EACH(
+  UPDATE(foo, ...),
+  UPDATE(bar, ...)
+)
+=>
+[Results of UPDATE queries]
+
+```
+
+### UPDATE
+Updates attributes or elements based on the specified conditions or inputs, with various strategies (absolute, relative_total, or relative_per_year).
+
+```
+UPDATE(L(foo), demand, 100)
+=>
+Demand becomes 100
+
+UPDATE(L(foo, bar, baz), demand, 5)
+=>
+Demand of all nodes becomes 5
+
+```
+### UPDATE_WITH_FACTOR
+Same as UPDATE, but the input value is expected to be a factor that the user supplies.
+Example:
+```
+UPDATE_WITH_FACTOR(V(foo), preset_demand, 1.1)
+=>
+Foo gets a demand of 110.0
+
+```
+
+### UPDATE_ABSOLUTE
+Same as UPDATE, but forcefully behaving as the absolute strategy.
+Example:
+```
+UPDATE_ABSOLUTE(L(foo), demand, 500)
+=>
+Demand of foo becomes 500
+
+```
+
+### USER_INPUT
+Retrieves the numeric value of the user input, handling different formats (absolute, percentage, etc.).
+Example:
+```
+USER_INPUT()
+=>
+3.0 (if the user input is "3")
+```
+
+### INPUT_VALUE(key)
+Retrieves the value of a specified input.
+Example:
+```
+INPUT_VALUE('agriculture_geothermal_share')
+=>
+0.104
+```
+
+### UPDATE_OBJECT()
+Accesses the currently updated object in the context of an UPDATE statement.
+Example:
+```
+UPDATE(L(foo, bar), demand, -> {V(UPDATE_OBJECT(), demand) + USER_INPUT()})
+=>
+[Increments demand of foo and bar based on user input]
+
+```
+
+### UPDATE_COLLECTION()
+Accesses all objects in the current UPDATE statement.
+Example:
+```
+UPDATE(L(foo, bar, baz), demand, -> {
+  SUM(V(UPDATE_COLLECTION(), demand)) - V(UPDATE_OBJECT(), demand)
+})
+=>
+[Updates demands of foo, bar, baz with the remainder]
+```
+# Old documenatation 
+
 
 Made to be able to draw information from the graph. Many types of information can be queried. Ask one of the programmers for a automated version of this page, which is available in the code.
 
-ABS(values, arguments, scope = nil)
+### ABS(values, arguments, scope = nil)
 -------------------------------
 @param values [Array] @return [Array] absolute numbers
 
-ALL(keys, arguments, scope)
+### ALL(keys, arguments, scope)
 ---------------------------
 
 All Converters in the graph. Use wisely. @return [Array
 
-AREA(keys, arguments, scope)
+### AREA(keys, arguments, scope)
 ----------------------------
 
 {Qernel::Area Graph} attribute of current country: \*AREA(available\_land)\* @param keys [String] Attribute of area @return [Float]
 
-AVG(values, arguments, scope = nil)
+### AVG(values, arguments, scope = nil)
 -------------------------------
 @param values [Array] @return [Float] Average of values (ignoring nil values)
 
-CARRIER(keys, arguments, scope)
+### CARRIER(keys, arguments, scope)
 -------------------------------
 
 {Qernel::Carrier Carrier} with the keys: \*CARRIER(electricity)\* @param keys [Array] Carrier key(s) @return [Array]
 
-CHILDREN(converters, arguments, scope)
+### CHILDREN(converters, arguments, scope)
 --------------------------------------
 
 Children of a converter(s). e.g.
@@ -845,23 +1254,23 @@ CHILDREN(V(small_chp_industry_energetic))
 ```
 @param converters [String] converters @return [Array] direct children of the converters
 
-COMPARE(values, arguments, scope = nil)
+### COMPARE(values, arguments, scope = nil)
 -------------------------------
 @param values [Float,Float] Two values. @return [-1,0,1]
 
-COUNT(values, arguments, scope = nil)
+### COUNT(values, arguments, scope = nil)
 -------------------------------
 How many (non-nil) values are there? @param values [Array] @return [Integer] Size of array (ignoring nil values)
 
-DIVIDE(values, arguments, scope = nil)
+### DIVIDE(values, arguments, scope = nil)
 -------------------------------
 @param values [Float,Float] @return [Float]
 
-EQUALS(values, arguments, scope = nil)
+### EQUALS(values, arguments, scope = nil)
 -------------------------------
 @param values [Float,Float] @return [Boolean] true if first equals second
 
-EXCLUDE(keys, arguments, scope = nil)
+### EXCLUDE(keys, arguments, scope = nil)
 -------------------------------
 Returns the intersection of two sets of converters. e.g.
 ```
@@ -870,14 +1279,14 @@ EXCLUDE([dennis,willem,alexander],[dennis])
 ```
 @param keys [Array,Array] @return [Array]
 
-FILTER(converters, filter\_name, scope)
+### FILTER(converters, filter\_name, scope)
 ---------------------------------------
 
 Selects only the converters that return true to the given instance\_evaled ruby string.
 
 FILTER(ALL(); electricity\_input \> 0) @param converters [String] converters
 
-FOR\_COUNTRIES(value\_terms, arguments, scope = nil)
+### FOR\_COUNTRIES(value\_terms, arguments, scope = nil)
 -------------------------------
 Excecutes statement only if Current.scenario.country is in parameter list. Note: separate countries with “;“ e.g.
 ```
@@ -887,12 +1296,12 @@ FOR_COUNTRIES(5;de;en;it)
 => if not.
 => nil
 ```
-G(keys, arguments, scope)
+### G(keys, arguments, scope)
 -------------------------
 
 Alias for: GROUP
 
-GOAL(key)
+### GOAL(key)
 ---------
 
 Returns the GOAL object with the \`key\name. The only important attribute of the GOAL object is \`user\_value\`.
@@ -914,25 +1323,26 @@ If the user didn't set any value then user\_value will be nil. To check if the u
 ```
 that will return a boolean.
 
-GRAPH(keys, arguments, scope)
+
+### GRAPH(keys, arguments, scope)
 -----------------------------
 
 {Qernel::GraphApi Graph} attributes: \*GRAPH(method)\* @see Qernel::GraphApi @param keys [String] GraphApi method @return [Float]
 
-GREATER(values, arguments, scope = nil)
+### GREATER(values, arguments, scope = nil)
 -------------------------------
 GREATER(2,1) =\> true @param values [Float,Float] @return [Boolean] true if first is greater then second
 
-GREATER\_OR\_EQUAL(values, arguments, scope = nil)
+### GREATER\_OR\_EQUAL(values, arguments, scope = nil)
 -------------------------------
 @param values [Float,Float] @return [Boolean] true if first is greater or equal then second
 
-GROUP(keys, arguments, scope)
+### GROUP(keys, arguments, scope)
 -----------------------------
 
 Converters of a {Qernel::Group Group}: \*GROUP(primary\_demand\_cbs)\* @param keys [Array] Group key(s) @return [Array] Also aliased as: G
 
-IF(value\_terms, arguments, scope = nil)
+### IF(value\_terms, arguments, scope = nil)
 -------------------------------
 If statement, with a check clause (condition) and two values.
 ```
@@ -947,7 +1357,7 @@ IF(LESS(1,3),IF(LESS(3,1),50,10),100)
 ```
 @param statements [Array] Expects 3 statements: condition, value if true, value if false @raise [GqlError] if condition statement is not boolean @raise [GqlError] if arguments does not contain 3 statements @return [Object]
 
-INTERSECTION(keys, arguments, scope = nil)
+### INTERSECTION(keys, arguments, scope = nil)
 -------------------------------
 Returns the intersection of two sets of converters. e.g.
 ```
@@ -968,49 +1378,49 @@ INTERSECTION(GROUP(team_members),V(dennis,willem))
 ```
 @param keys [Array,Array] Intersection of two converter arrays @return [Array]
 
-NVALID\_TO\_ZERO(values, arguments, scope = nil)
+### INVALID\_TO\_ZERO(values, arguments, scope = nil)
 -------------------------------
 converts nil and NaN values to zero values @param values [Float,Array] @return [Float,Array] Array with nil or NaN values converted to zero
 
-INVERSE(values, arguments, scope = nil)
+### INVERSE(values, arguments, scope = nil)
 -------------------------------
 @param values [Float] @return [Float] 1 / x of value
 
-IS\_NIL(value, arguments, scope = nil)
+### IS\_NIL(value, arguments, scope = nil)
 -------------------------------
 checks if value is nil @param value [Float] @return [Boolean] Is the argument a numeric
 
-IS\_NUMBER(value, arguments, scope = nil)
+### IS\_NUMBER(value, arguments, scope = nil)
 -------------------------------
 Is the value a number (and not nil or s’thing else). @param value [Float] @return [Boolean] Is the argument a numeric
 
-LESS(values, arguments, scope = nil)
+### LESS(values, arguments, scope = nil)
 -------------------------------
-LESS(1,2) =\> true LESS(1,1) =\> false @param values [Float,Float] @return [Boolean] true if first is less then second
+### LESS(1,2) =\> true LESS(1,1) =\> false @param values [Float,Float] @return [Boolean] true if first is less then second
 
-LESS\_OR\_EQUAL(values, arguments, scope = nil)
+### LESS\_OR\_EQUAL(values, arguments, scope = nil)
 -------------------------------
 LESS\_OR\_EQUAL(1,1) =\> true @param values [Float,Float] @return [Boolean] true if first is less or equal then second
 
-MAX(values, arguments, scope = nil)
+### MAX(values, arguments, scope = nil)
 -------------------------------
 @param values [Array] @return [Float] the highest number
 
-MIN(values)
+### MIN(values)
 -----------
 
 @param values [Array] @return [Float] the lowest number
 
-MIXED(q1,q2)
+### MIXED(q1,q2)
 ------------
 
 This will run two different queries, one for the present and one for the future graph. This is mainly used for chart series.
 
-NEG(values, arguments, scope = nil)
+### NEG(values, arguments, scope = nil)
 -------------------------------
 @param values [Float] @return [Float] -(value)
 
-NIL()
+### NIL()
 -----
 
 Returns a nil value. mainly used for testing. e.g.
@@ -1021,7 +1431,7 @@ NIL\_TO\_ZERO(values, arguments, scope = nil)
 -------------------------------
 convert nil values to zero values @param values [Float,Array] @return [Float,Array] Array with nil values converted to zero
 
-NOT(values, arguments, scope = nil)
+### NOT(values, arguments, scope = nil)
 -------------------------------
 @param values [Boolean] @return [Boolean] inverse of values
 
@@ -1029,7 +1439,7 @@ OR(values, arguments, scope = nil)
 -------------------------------
 @param values [Array] @return [Boolean] Any of the values true?
 
-PARENTS(converters, arguments, scope)
+### PARENTS(converters, arguments, scope)
 -------------------------------------
 
 Direct parents of a converter(s). e.g.
@@ -1038,21 +1448,21 @@ PARENTS(V(small_chp_industry_energetic))
 ```
 @param converters [String] converters @return [Array] direct parents of the converters
 
-PRODUCT(values, arguments, scope = nil)
+### PRODUCT(values, arguments, scope = nil)
 -------------------------------
 PRODUCT(1,2,3) =\> 1 \* 2 \* 3 =\> 6 @param values [Array] @return [Float] Product of all values (ignoring nil values).
 
-Q(keys, arguments, scope)
+### Q(keys, arguments, scope)
 -------------------------
 
 Alias for: QUERY
 
-QUERY(keys, arguments, scope)
+### QUERY(keys, arguments, scope)
 -----------------------------
 
 Executes a subquery with the given key (all stored Gqueries (see /admin/gqueries) can act as subquery): \*QUERY( total\_energy\_cost )\* @param keys [String] The key of the subquery (Gquery) @return The result of the subquery Also aliased as: Q, SUBQUERY
 
-RESCUE(value\_terms, params, scope = nil)
+### RESCUE(value\_terms, params, scope = nil)
 -------------------------------
 Returns the parameter value (or 0.0 as default) if an error is raised in the value. e.g.
 ```
@@ -1067,22 +1477,22 @@ RESCUE( SUM(1,2); 100.0)
 ```
 @return [Object] returns the value or the parameter if rescues an exception
 
-SECTOR(keys, arguments, scope)
+### SECTOR(keys, arguments, scope)
 ------------------------------
 
 Converters of a sector : \*SECTOR(households)\* @see Qernel::Converter::SECTORS list of sectors @param keys [Array] Sector key(s) @return [Array]
 
-SUBQUERY(keys, arguments, scope)
+### SUBQUERY(keys, arguments, scope)
 --------------------------------
 
 @deprecated Alias for: QUERY
 ```
-SUM(values, arguments, scope = nil)
+### SUM(values, arguments, scope = nil)
 ```
 -------------------------------
 Sum of a list of values. @param values [Array] @return [Float] Sum of values (ignoring nil values)
 
-NIT(values, arguments, scope = nil)
+### UNIT(values, arguments, scope = nil)
 -------------------------------
 Converts a value to another format. Know what you do! Especially useful to write more readable Queries:
 ```
@@ -1092,16 +1502,16 @@ UNIT(0.15;percentage) => 15.0 (%)
 ```
 @param values [Float] @return [Float] Converted value
 
-USE(keys, arguments, scope)
+### USE(keys, arguments, scope)
 ---------------------------
 
 Converters of a “energy use”: energetic, non\_energetic, undefined: \*USE(energetic)\* @see Qernel::Converter::USE list of energy uses @param keys [Array] Use key(s) @return [Array]
 
-V(converters, attribute\_name, scope = nil)
+### V(converters, attribute\_name, scope = nil)
 -------------------------------
 Alias for: VALUE
 
-VALUE(converters, attribute\_name, scope = nil)
+### VALUE(converters, attribute\_name, scope = nil)
 -------------------------------
 VALUE returns the attributes for a set of Converters. Note that duplicate converters are removed, so that
 ```
@@ -1151,3 +1561,5 @@ foo_bar_converters: VALUE( foo, bar )
 SUM( VALUE( Q(foo_bar_converters); demand) )
 ```
 @param keys [Array] A list of converters. @param attribute\_name [String] A ruby expression that is instance\_evaled for the selected converters. @return [Array] @return [Array] if no attribute\_name is defined. Also aliased as: V
+
+

--- a/docs/contrib/gql.md
+++ b/docs/contrib/gql.md
@@ -6,7 +6,7 @@ GQL is used to calculate values that are used in the graphs, tables and figures 
 
 ## Gqueries
 
-Gqueries are in fact stored GQL procedures that have a key. So that if the user wants to know the total co2 emissions of an area, it can request the ETEngine for gquery `total_co2_emissions` and does not have to worry about the underlying intricacies.
+Gqueries are in fact stored GQL procedures that have a key. So that if the user wants to know the total co2 emissions of an area, it can request ETEngine for the gquery `total_co2_emissions` and does not have to worry about the underlying intricacies.
 
 ### Writing gqueries
 
@@ -17,7 +17,7 @@ GQL is case sensitive. Since all GQL-functions are written in caps, this means t
 - Base gqueries have a consistent set of base units, for example `kg` for **emissions**, `MW` for **capacity** and `MJ` for **energy**.
 - Base gqueries have a consistent nomenclature: for example **type**, **subtype**, **sector**, **subsector**, **carrier**.
 - Base gqueries should have a description.
-- To enhance readability, our preferred indentation style for Gqueries involves initially indenting with 4 spaces, followed by an additional 2 spaces for subsequent levels.
+- To enhance readability, the preferred indentation style for gqueries is first to indent with 4 spaces, followed by an additional 2 spaces for each subsequent level (see the example below).
 
 Example for `final_demand_energetic_industry_steel_wood_pellets`:
 ```
@@ -735,7 +735,7 @@ OUTPUT_EDGES(V(foo, bar))
 
 ### Curves functions
 
-With these functions you can perform operations with curves from the merit or fever modules.
+With these functions you can perform operations with curves from the merit modules.
 
 #### CLAMP_CURVE(curve, min, max)
 
@@ -917,9 +917,9 @@ Returns an Array of all nodes in the energy graph.
 #### MALL()
 Returns an Array of all nodes in the molecule graph.
 
-#### GROUP(group)
+#### G(group)
 
-Returns an Array of all nodes for a given energy graph group.
+Abbreviation of GROUP. Returns an Array of all nodes for a given energy graph group.
 
 ```ruby
 GROUP(apartments)
@@ -934,9 +934,9 @@ GROUP(apartments)
 ]
 ```
 
-#### MGROUP(group)
+#### MG(group)
 
-Returns an Array of all nodes for a given molecule graph group.
+Abbreviation of MGROUP. Returns an Array of all nodes for a given molecule graph group.
 
 ```ruby
 MGROUP(ccu_emitted)
@@ -946,9 +946,10 @@ MGROUP(ccu_emitted)
 ]
 ```
 
-#### EDGE_GROUP(group)
-Returns an Array of all nodes for a given energy graph edge group.
+#### EG(group)
+Abbreviation of EDGE_GROUP. Returns an Array of all nodes for a given energy graph edge group.
 
+```ruby
 EG(final_demand)
 =>
 [
@@ -959,16 +960,15 @@ EG(final_demand)
 ]
 ```
 
-#### MEDGE_GROUP(group)
-Returns an Array of all nodes for a given energy graph molecul edge group.
-
+#### MEG(group)
+Abbreviation of MEDGE_GROUP. Returns an Array of all nodes for a given energy graph molecule edge group.
 
 #### SECTOR(sector)
 
 Returns an Array of nodes for a given energy sector.
 
 ```ruby
-###SECTOR(households)
+SECTOR(households)
 =>
 [
   #<Node households_apartments_useful_demand_for_space_heating>,
@@ -1042,8 +1042,9 @@ FILTER(G(electricity_production),"geothermal_input_conversion > 0.0")
 These functions concern operations associated with the Fever module.
 
 #### FEVER_DEMAND(groups)
-Outputs the yearly summed demand-curve of the specified fever group.
-The fever groups that can be chosen from are: buildings_space_heating, households_hot_water and space_heating
+
+Outputs the yearly summed demand curve of all consumers in the specified Fever group. The Fever groups that can be chosen from are: `buildings_space_heating`, `households_hot_water` and `space_heating`
+
 
 ```ruby
 FEVER_DEMAND(buildings_space_heating)
@@ -1054,31 +1055,11 @@ FEVER_DEMAND(buildings_space_heating)
   ...,
   6,931.270889166959
 ]
-
-FEVER_DEMAND(households_hot_water)
-=> 
-[
-  0.0,
-  0.0,
-  ...,
-  0.0
-]
-
-FEVER_DEMAND(space_heating)
-=> 
-[
-13,224.03964104562,
-12,848.980134095127,
-...,
-15,208.97143065297
-]
 ```
 
 #### FEVER_PRODUCTION(groups)
 
-
-Outputs the yearly summed demand-curve of the specified fever group.
-The fever groups that can be chosen from are: buildings_space_heating, households_hot_water and space_heating
+Outputs the yearly summed supply curve of all consumers in the specified Fever group. The fever groups that can be chosen from are: `buildings_space_heating`, `households_hot_water` and `space_heating`.
 
 ```ruby
 FEVER_PRODUCTION(buildings_space_heating)
@@ -1089,38 +1070,46 @@ FEVER_PRODUCTION(buildings_space_heating)
   ...,
   6,931.270889166959
 ]
-
-FEVER_PRODUCTION(households_hot_water)
-=> 
-[
-  0.0,
-  0.0,
-  ...,
-  0.0
-]
-
-FEVER_PRODUCTION(space_heating)
-=> 
-[
-13,224.03964104562,
-12,848.980134095127,
-...,
-15,208.97143065297
-]
 ```
 
 #### FEVER_PRODUCTION_CURVE_FOR_COUPLE(producer,consumer)
-A yearly curve describing the production in MWh of a specific producer for a specific consumer within Fever.
 
+A yearly curve specifying the production of a producer node in Fever for a consumption node.
 
+```ruby
+FEVER_PRODUCTION_CURVE_FOR_COUPLE(
+  V(households_space_heater_combined_network_gas),
+  V(households_useful_demand_for_space_heating_terraced_houses_1965_1984)
+)
+=> 
+[
+  941.3148533148487,
+  ...,
+  1,068.1549289644927,
+]
+```
 
 #### FEVER_DEMAND_CURVE_FOR_COUPLE(producer,consumer)
-A yearly curve describing the demand in MWh of a specific consumer for a specific consumer within Fever.
 
+A yearly curve specifying the demand of a consumption node in Fever for supply of a production node. The difference between the `FEVER_PRODUCTION_CURVE_FOR_COUPLE` and the `FEVER_DEMAND_CURVE_FOR_COUPLE` is marked as a deficit.
 
+```ruby
+FEVER_DEMAND_CURVE_FOR_COUPLE(
+  V(households_space_heater_combined_network_gas),
+  V(households_useful_demand_for_space_heating_terraced_houses_1965_1984)
+)
+=> 
+[
+  941.3148533148487,
+  ...,
+  1,068.1549289644927,
+]
+```
 
 #### FEVER_PRODUCTION_CURVE(node)
-A yearly curve describing the production in MWh of/for a specific consumer or producer within Fever.
+
+A yearly curve describing the production for a specific consumer or of a producer within Fever.
+
 ```ruby
 FEVER_PRODUCTION_CURVE(V(households_useful_demand_for_space_heating_semi_detached_houses_1985_2004))
 => 
@@ -1132,7 +1121,9 @@ FEVER_PRODUCTION_CURVE(V(households_useful_demand_for_space_heating_semi_detache
 ```
 
 #### FEVER_DEMAND_CURVE(node)
-A yearly curve describing the demand in MWh of/for a specific consumer or producer within Fever.
+
+A yearly curve describing the demand of a specific consumer or from producer within Fever. The difference between the `FEVER_PRODUCTION_CURVE` of a producer and the `FEVER_DEMAND_CURVE` from producer is marked as a deficit. The difference between the `FEVER_PRODUCTION_CURVE` for a consumer and the `FEVER_DEMAND_CURVE` of a consumer is marked as a deficit.
+
 ```ruby
 FEVER_DEMAND_CURVE(V(households_useful_demand_for_space_heating_semi_detached_houses_1985_2004))
 => 
@@ -1142,8 +1133,6 @@ FEVER_DEMAND_CURVE(V(households_useful_demand_for_space_heating_semi_detached_ho
   462.08107903258804
 ]
 ```
-
-
 
 ### Update functions
 

--- a/docs/contrib/gql.md
+++ b/docs/contrib/gql.md
@@ -17,7 +17,7 @@ GQL is case sensitive. Since all GQL-functions are written in caps, this means t
 - Base gqueries have a consistent set of base units, for example `MW` for **capacity** and `MJ` for **energy**.
 - Base gqueries have a consistent nomenclature: for example **type**, **subtype**, **sector**, **subsector**, **carrier**.
 - Base gqueries should have a description.
-- Gqueries indent first with 4 spaces, then with 2 spaces.
+- To enhance readability, our preferred indentation style for Gqueries involves initially indenting with 4 spaces, followed by an additional 2 spaces for subsequent levels.
 
 Example for `final_demand_energetic_industry_steel_wood_pellets`:
 ```
@@ -128,11 +128,21 @@ DIVIDE(1,2,3,4)
 => 0.5 --> only takes the second.
 ```
 
-#### INVALID_TO_ZERO(*keys)
+#### INVALID_TO_ZERO(keys)
 
-TO-DO
+When an invalid value is given, a zero is returned.
+```ruby
+INVALID_TO_ZERO(nil)
+=> 0
 
-#### MAX(*values)
+INVALID_TO_ZERO(3)
+=> 3
+
+INVALID_TO_ZERO([3,3,nil,4])
+=> [3,3,0,4]
+```
+
+#### MAX(values)
 
 Returns the highest number.
 
@@ -141,7 +151,7 @@ MAX(-3,-2,5)
 => 5
 ```
 
-#### MIN(*values)
+#### MIN(values)
 
 Returns the lowest number.
 
@@ -150,7 +160,7 @@ MIN(-3,-2,5)
 => - 3
 ```
 
-#### ABS(*values)
+#### ABS(values)
 
 Returns all given numbers in absolute values.
 
@@ -186,7 +196,7 @@ CEIL(3.5)
 => 4
 ```
 
-#### SQRT(*values)
+#### SQRT(values)
 
 Returns the square root of the given values.
 
@@ -303,8 +313,22 @@ NOT(1,1,5)
 => false
 ```
 
-#### OR
-TO-DO
+#### OR(values)
+Takes any number of arguments and checks if any of the arguments are true. 
+If any are true, the functions returns 'true'. If not, false is returned.
+```ruby
+OR(true,false) 
+=> true --> true is one of the arguments.
+
+OR(false,false)
+=> false --> true is not one of the arguments
+
+OR(3,3)
+=> false --> true is not one of the arguments
+```
+
+
+
 
 #### IS_NUMBER(x)
 
@@ -462,13 +486,21 @@ Q(total_costs)
 => 100
 ```
 
-#### CHILDREN(*nodes)
+#### CHILDREN(nodes)
 
-TO-DO
+Outputs the nodes corresponding to the outgoing edges of the given node.
+```ruby
+CHILDREN(V(households_space_heater_coal))
+=> <Node households_final_demand_for_space_heating_coal>
+```
 
-#### PARENTS(*nodes)
+#### PARENTS(nodes)
+```ruby
+PARENTS(V(households_space_heater_coal))
+=> <Node households_space_heater_coal_aggregator>
+```
 
-TO-DO
+Outputs the nodes corresponding to the incoming edges of the given node.
 
 #### QUERY_PRESENT(key)
 
@@ -518,11 +550,11 @@ Q(graph_year)
 
 QUERY_FUTURE(graph_year)  
 =>
-2,019
+2,050
 
 QUERY_FUTURE( -> { GRAPH(year) } )   
 => 
-2,019
+2,050
 
 QUERY_FUTURE(GRAPH(year))   
 => 
@@ -719,7 +751,7 @@ CLAMP_CURVE([1,-2,3,-4],0,2)
 
 #### COALESCE_CURVE(curve, default = 0.0, length = 8760)
 
-If the given `curve` is an array of non-zero length, it is returned. If the curve is nil or empty, a new curve of `length` length is created, with each value set to `default`.
+If the given `curve` is an array of non-zero length, it is returned. If the curve is nil or empty, a new curve with the lentgh of the value that is given to `length` is created, each value in the curve is set to the value that is given to `default`.
 
 ```ruby
 COALESCE_CURVE(nil,3,5)
@@ -757,7 +789,7 @@ INVERT_CURVE([1,-2,3,-4])
 ```
 
 
-#### SUM_CURVES(*curves)
+#### SUM_CURVES(curves)
 
 Adds the values in multiple curves.
 
@@ -787,15 +819,23 @@ DIVIDE_CURVES([1, 2, 3], [4, 5, 6])
 
 #### SMOOTH_CURVE(curve, window_size)
 
-Creates a smoothed curve using a moving average.
-curve       - An array of numbers.
-window_size - The number of points to average over.
+Creates a smoothed curve using a moving average. `curve` is the curve you want to use as input, the `window_size` is the number of points the curve will be averaged over.
+
+```ruby
+SMOOTH_CURVE([3,2,4,3],1)
+=> [3,2,4,3] --> Returns the input curve since each point is averaged on only one point.
+```
+```ruby
+SMOOTH_CURVE([3,2,4,3],2)
+=> [3,2.5,3,3.5] --> Returns a differenct curve since the window_size is bigger.
+```
+
 
 ### Helper functions
 
 These functions can support the user in gaining a quick insight in the data. See the examples below for use cases of these functions.
 
-#### SORT_BY(*objects, arguments)
+#### SORT_BY(objects, arguments)
 
 With SORT_BY nodes can be sorted on one of their attributes. The nodes will be sorted ascending to the value of the attribute. Ranking of the nodes will start from 0. Note that the value of the attribute will not be printed, see TXT_TABLE for this functionality.
 
@@ -958,7 +998,7 @@ CARRIER(electricity)
 
 Returns an Array of carriers for given key(s). Returns carriers belonging to the molecule graph. See CARRIER.
 
-#### INTERSECTION(*keys)
+#### INTERSECTION(keys)
 
 Returns the elements that are present in both the first and second arrays.
 
@@ -967,7 +1007,7 @@ INTERSECTION( V(1,2,3) , V(2,3,4) )
 => [2, 3]
 ```
 
-#### EXCLUDE(*keys)
+#### EXCLUDE(keys)
 
 Returns an Array of elements of the first array excluding the second array.
 
@@ -1042,17 +1082,6 @@ Same as `UPDATE`, but the input value is expected to be a factor that the user s
 UPDATE_WITH_FACTOR(V(foo), preset_demand, 1.1)
 =>
 Foo gets a demand of 110.0
-
-```
-
-#### UPDATE_ABSOLUTE()
-
-Same as `UPDATE`, but forcefully behaving as the absolute strategy.
-
-```ruby
-UPDATE_ABSOLUTE(V(foo), demand, 500)
-=>
-Demand of foo becomes 500
 
 ```
 

--- a/docs/contrib/gql.md
+++ b/docs/contrib/gql.md
@@ -1,0 +1,1153 @@
+---
+title: Graph Query Language (GQL)
+---
+# General information GQL
+
+GQL is used to calculate values that are used in the graphs, tables and figures that can be viewed in the model. Users can check values themselves by using the GQL-sandbox in ETEngine. This can be found here --> [Link]
+
+
+Please note that the output that is printed in this documentation is dependent on the scenario the user is using. 
+
+GQL is case sensitive. Since all GQL-functions are written in caps, this means that all functions **must** be written in caps in order to function.
+
+
+List of all functions:
+
+# Aggregate:
+
+### COUNT(values)
+
+Returns how many values. Removes nil values, but does not remove duplicates. 
+
+*Basic example*:
+
+```
+COUNT(1) 
+=> 1
+COUNT(1,2)  
+=> 2
+```
+*Node example*:
+
+```
+COUNT(L(foo,bar)) 
+=> 2
+```
+
+*multiple LOOKUPS (does not remove duplicates)*
+
+```
+COUNT(L(foo,bar), L(foo)) 
+=> 3
+```
+
+*Duplicates in one LOOKUP (does remove duplicates)*
+```
+COUNT(L(foo,bar,foo))
+=> 2
+```
+
+### NEG(values)
+
+Returns the *first* number as a negative
+
+*example*:
+
+```
+NEG(2) 
+=> -2
+
+NEG(1,2,3)  
+=> -1
+```
+
+AVG(values)
+Returns the average of all number (ignores nil values).
+```
+AVG(1,2)    
+=> 1.5
+
+AVG(1,2,3)  
+=> 2
+
+AVG(1,nil,nil,2)  
+=> 1.5
+```
+
+SUM
+Returns the sum of all numbers (ignores nil values).
+```
+SUM(1,2) 
+=> 3
+SUM(1,nil)  
+=> 1
+```
+
+### PRODUCT(values)
+
+Multiplies all numbers (ignores nil values).
+
+```
+PRODUCT(1,2,3)
+=>6 (1*2*3)
+
+PRODUCT(1,nil)
+=> 1
+```
+
+
+### DIVIDE(values)
+
+Divides the first with the second.
+```
+DIVIDE(1,2)
+=> 0.5
+
+DIVIDE(1,2,3,4)
+=> 0.5 --> only takes the second.
+```
+
+Constants:
+
+MWH_TO_GJ = 3.6
+
+HOURS_PER_YEAR = 8760.0
+
+MAN_HOURS_PER_MAN_YEAR = 1800.0
+
+MAN_YEAR_PER_MJ_INSULATION_PER_YEAR = 0.0000000122916
+
+SECS_PER_HOUR = 3600.0
+
+SECS_PER_YEAR = SECS_PER_HOUR * HOURS_PER_YEAR
+
+KG_PER_TONNE = 1000
+
+LITER_PER_BARREL = 159
+
+MJ_TO_MHW = 3600
+
+MJ_PER_KWH = 3.6
+
+MJ_PER_MWH = 3600
+
+BILLIONS = 10.0**9
+
+MJ_TO_PJ = BILLIONS
+
+MILLIONS = 10.0**6
+
+THOUSANDS = 1000.0
+
+#NIL = nil if !defined?(NIL)
+
+EURO_SIGN = '&euro;'
+
+MONTHS_PER_YEAR = 12.0
+
+INFINITY = Float::INFINITY
+
+# Control
+
+
+
+
+### EQUALS(values)
+
+Checks if the **first two** values are given are equal.
+
+```
+EQUALS(2,2)
+=> true
+
+EQUALS(2,3)
+=> false
+
+EQUALS(2,2,3)
+=> true
+
+EQUALS(2,3,3)
+=> false
+```
+
+### IF(condition, true_stmt, false_stmt)
+If the condition is true, the true_stmt is given, if the condition is false, the false_stmt is given. 
+```
+IF(EQUALS(1,1),3,4) 
+=> 3 --> EQUALS(1,1) returns 'true', so 3 is returned.
+
+IF(EQUALS(1,2),3,4)
+=> 4 --> EQUALS(1,2) returns 'false', so 4 is returned.
+```
+
+# Core
+
+### V(args)
+
+Shortcup for the LOOKUP and MAP function. Also see {#LOOKUP} and {#MAP}.
+
+Example with node
+```
+V(foo) --> LOOKUP(foo)
+=> foo
+```
+
+Example Lookup multiple nodes by their keys
+```
+V(foo,bar) --> LOOKUP(foo,bar)
+=> [<foo>, <bar>]
+```
+
+Example Lookup a node attribute
+```
+V(foo,demand) --> MAP(LOOKUP(foo,demand))
+=> 100 (When demand of node 'foo' is equal to 100)
+```
+
+Example nesting of LOOKUPs
+```
+V(V(foo), V(bar), demand) --> MAP(LOOKUP(foo, LOOKUP(bar)), demand)
+=> 100, 200 
+```
+
+Example pass objects to V()
+```
+V(CARRIER(electricity), cost_per_mj) --> = MAP( LOOKUP(CARRIER(electricity)), cost_per_mj )
+=> 23.3
+```
+### VALUE(args)
+
+Alias for V()
+
+### MV(args)
+
+Same functionalities as V, but used for the molecule graph. 
+
+### Q(key)
+
+QUERY() or Q() returns the result of another gquery with given key.
+
+Example costs
+
+```
+Q(total_costs)
+=> 100
+```
+
+### Query(key)
+
+Alias for Q()
+
+
+### Lookup(keys)
+
+lookup energy graph objects by their corresponding key(s).
+keys - Provided keys should be energy graph node keys or Qernel objects 
+Returns an array of the elements of the query: matching nodes or objects. Duplicates and nil values are removed.
+
+Example 1 or 2 nodes:
+
+```
+LOOKUP(foo)  
+=> [Node(foo)]
+
+LOOKUP(foo, bar) 
+=> [Node(foo), Node(bar)]
+```
+
+Elements that are not node keys are simply returned:
+```
+LOOKUP(foo,3.0)  
+=> [Node(foo),3.0]
+
+LOOKUP(foo, CARRIER(coal)) 
+=> [Node(foo), Carrier(coal)]
+```
+
+nil and duplicate elements are removed:
+
+```
+LOOKUP(foo,nil)  
+=> [Node(foo)]
+
+LOOKUP(foo, Lookup(foo)) 
+=> [Node(foo)]
+```
+
+### L(keys)
+Alias for Lookup
+
+### ML(keys)
+
+Lookup or L for the moleculegraph, alias for MLOOKUP
+
+### MLOOKUP(keys)
+Lookup or L for the moleculegraph, alias for ML.
+
+### MAP(elements, attr_name)
+
+Access attributes of one or more objects.
+
+=== Single and composed attributes
+To query a single attribute simply pass it. You can put it inside '', "" or not.
+
+To join multiple attributes and numbers surround it with "" or ''.
+
+=== GQL functions as arguments
+
+You can pass a GQL function as an argument to a *single* method.
+Attributes dervied from GQL functions cannot be inside "" or ''.
+
+Example with a single attribute:
+```
+MAP(L(foo), demand)
+=> 100
+
+MAP(L(foo), "demand")
+=> 100
+
+MAP(L(foo,bar), demand)
+=> [100, 200]
+```
+
+Example Composed attributes add "" or ''
+
+```
+MAP(L(foo), 'demand * (3.0 + free_co2_factor)')
+=> 100
+```
+
+```
+MAP(L(foo), primary_demand_of(CARRIER(electricity)))
+```
+ ### TODO
+
+### M(elements,attr_name)
+
+ALIAS for MAP
+
+### GET(keys)
+
+Retrieves the attribute from one *single* object and is therefore similar to MAP.
+
+
+# Curves
+
+### ATTACHED_CURVE(name)
+
+Looks up the attachment matching the `name`, and converts the contents into a curve. If no attachment is set, nil is returned.
+
+### CLAMP_CURVE(curve, min, max)
+
+Restricts the values in a curve to be between the minimum and maximum. Raises an error if min > max.
+
+### COALESCE_CURVE(curve, default = 0.0, length = 8760)
+
+If the given `curve` is an array of non-zero length, it is returned. If the curve is nil or empty, a new curve of `length` length is created, with each value set to `default`.
+
+### CUMULATIVE_CURVE(curve)
+
+Creates a new curve where each index (n) is the sum of (0..n) in the source curve.
+
+
+### INVERT_CURVE(curve)
+
+Inverts a single curve by swapping positive numbers to be negative, and vice-versa.
+
+### SUM_CURVES(*curves)
+Adds the values in multiple curves.
+
+Example:
+
+```
+SUM_CURVES([1, 2], [3, 4])
+=> [4, 6]
+
+SUM_CURVES([[1, 2], [3, 4]])
+=> [4, 6]
+```
+
+
+### PRODUCT_CURVES(left,right)
+Multiplies two curves elementwise.
+Note that unlike `SUM_CURVES`, `PRODUCT_CURVES` expects exactly two arguments, each one a curve.
+An error will be raised if either parameter is an array of curves, or if the curves don't have matching lengths.
+
+Example:
+```
+PRODUCT_CURVES([1, 2, 3], [4, 5, 6])
+=> [4, 10, 18]
+```
+
+### DIVIDE_CURVES(left, right)
+Divides two curves elementwise.
+Note that unlike `SUM_CURVES`, `PRODUCT_CURVES` expects exactly two arguments, each one a curve.
+An error will be raised if either parameter is an array of curves, or if the curves don't have matching lengths.
+```
+DIVIDE_CURVES([1, 2, 3], [4, 5, 6])
+=> [0.25, 0.4, 0.5]
+```
+
+### SMOOTH_CURVE(curve, window_size)
+Creates a smoothed curve using a moving average.
+curve       - An array of numbers.
+window_size - The number of points to average over.
+
+# Helper
+
+### OBSERVE_SET(objects, arguments)
+
+OBSERVE_SET is mainly used to observe the graph calculation.
+It may be extended for more use. Observing update statements is done
+using Update#update_element_with in the debug runtime. 
+#### Might not be interesting for user.
+
+
+#### OBSERVE_GET(objects, arguments)
+
+#### todo
+#### Might not be interesting for user.
+
+#### SORT_BY(*objects, arguments)
+With SORT_BY nodes can be sorted on one of their attributes.
+The nodes will be sorted ascending to the value of the attribute.
+Ranking of the nodes will start from 0.
+Note that the value of the attribute will not be printed, see TXT_TABLE for this functionality.
+
+Example with the group 'useful_demand'.
+```
+SORT_BY(G(useful_demand),demand)
+=> 
+[
+  #<Node industry_useful_demand_for_chemical_other_hydrogen_non_energetic> 0,
+  #<Node bunkers_useful_demand_ships> 1,
+  ...,
+]
+```
+
+
+#### TXT_TABLE(objects, *argyments)
+With TXT_TABLE 1 or more attributes from a node group can be queried.
+The nodes in the given node group will be sorted alphabetically.
+
+Within the GQL-sandbox users can choose how the view the table in 4 different modes:
+* Table: Shows the table in standard GQL-sandbox format.
+* Text: Shows the table in text-format.
+* CSV: Shows the table in CSV (comma seperated values) format.
+* TSV: Shows the table in TSV (tab seperated values) format.
+
+Note: With 'key' the name of the node is printed.
+
+Example (output in text format, for readibility only the first 2 and last 2 rows of the table are shown):
+```
+TXT_TABLE(G(useful_demand),key,demand)
+=> 
++------------------------------------------------------------------------------+--------------------+
+|                                     key                                      |       demand       |
++------------------------------------------------------------------------------+--------------------+
+| agriculture_useful_demand_electricity                                        | 40964534066.695656 |
+| agriculture_useful_demand_useable_heat                                       | 98697676910.08954  
+|...                                                                           | ...                |
+| transport_useful_demand_trucks                                               | 144749566437.32986 |
+| transport_useful_demand_vans                                                 | 1280922944.4741797 |
++------------------------------------------------------------------------------+--------------------+
+```
+
+This function can be combined with SORT_BY, so that a quick overview of the nodes with the highest attributes can be found.
+
+Example with SORT_BY (output in text format, for readibility only the first 2 and last 2 rows of the table are shown):
+```
+TXT_TABLE(SORT_BY(G(useful_demand),demand),key,demand)
+=> 
++------------------------------------------------------------------------------+--------------------+
+|                                     key                                      |       demand       |
++------------------------------------------------------------------------------+--------------------+
+| industry_useful_demand_for_chemical_other_hydrogen_non_energetic             | 0.0                |
+| bunkers_useful_demand_ships                                                  | 0.0                |
+|...                                                                           | ...                |
+| industry_useful_demand_for_chemical_other_non_energetic                      | 414554538059.73004 |
+| industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic       | 2650973321780.0    |
++------------------------------------------------------------------------------+--------------------+
+```
+
+#### EXCEL_TABLE(objects, *arguments)
+Similar functionality to TXT_TABLE
+
+
+# Legacy
+
+#### FILTER(collection, filter)
+Imposes a filter.
+
+Can be used to impose a filter on node groups based on node attributes, see example.
+
+Example:
+
+```
+FILTER(G(electricity_production),"geothermal_input_conversion > 0.0")
+=> 
+[
+  <#Node energy_power_geothermal>,
+]
+```
+
+#### CHILDREN(*nodes)
+#### Todo
+
+#### PARENTS(*nodes)
+#### Todo
+
+#### INTERSECTION(*keys)
+Returns the elements that are present in both the first and second arrays.
+
+```
+INTERSECTION( V(1,2,3) , V(2,3,4) )
+=> [2, 3]
+```
+
+#### EXCLUDE(*keys)
+Returns an Array of elements of the first array excluding the second array.
+```
+EXCLUDE( V(1,2,3) , V(2,3,4) )
+=> [1]
+```
+#### INVALID_TO_ZERO(*keys)
+Deprecated?
+
+#### MAX(*values)
+Returns the highest number.
+```
+MAX(-3,-2,5)
+=> 5
+```
+#### MIN(*values)
+Returns the lowest number.
+```
+MIN(-3,-2,5)
+=> - 3
+```
+#### ABS(*values)
+Returns all given numbers in absolute values.
+```
+ABS(-3,-2,5)
+=> [3,2,5]
+```
+
+#### ROUND(value, precision = 0)
+Public: Rounds numeric value to a given precision.
+```
+ROUND(3.334,2)
+=> [3.33]
+```
+
+#### FLOOR(value, precision = 0)
+Returns the largest number less than or equal to numeric value.
+#### Todo
+
+#### CEIL(value, precision = 0)
+Returns the smallest number greater than or equal to numeric value.
+#### Todo
+
+#### SQRT(*values)
+Returns the square root of the given values.
+```
+SQRT(4) 
+=> [2]
+
+SQRT(4,9) 
+=> [2,3]
+
+SUM(SQRT(4,9)) 
+=> 5
+```
+
+#### LESS(x,y)
+Returns true when x is smaller than y.
+Note: This function only looks at the first two numbers entered in this function.
+
+```
+LESS(1,2) 
+=> true
+
+LESS(2,1) 
+=> false
+
+LESS(1,2,1)
+=> true
+
+LESS(1,2,5)
+=> true
+```
+
+
+#### LESS_OR_EQUAL(x,y)
+Returns true when x is smaller or equal than y.
+Note: This function only looks at the first two numbers entered in this function.
+
+```
+LESS_OR_EQUAL(1,2) 
+=> true
+
+LESS_OR_EQUAL(1,1) 
+=> true
+
+LESS_OR_EQUAL(2,1) 
+=> false
+
+LESS_OR_EQUAL(1,2,1)
+=> true
+
+LESS_OR_EQUAL(1,2,5)
+=> true
+```
+
+#### GREATER(x,y)
+Returns true when x is greater than y.
+Note: This function only looks at the first two numbers entered in this function.
+
+```
+GREATER(1,2) 
+=> false
+
+GREATER(2,1) 
+=> true
+
+GREATER(2,1,1)
+=> true
+
+GREATER(2,1,5)
+=> true
+```
+
+#### GREATER_OR_EQUAL(x,y)
+Returns true when x is smaller or equal than y.
+Note: This function only looks at the first two numbers entered in this function.
+
+```
+GREATER_OR_EQUAL(1,2) 
+=> false
+
+GREATER_OR_EQUAL(1,1) 
+=> true
+
+GREATER_OR_EQUAL(2,1) 
+=> true
+
+GREATER_OR_EQUAL(2,1,1)
+=> true
+
+GREATER_OR_EQUAL(2,1,5)
+=> true
+```
+
+#### EQUALS(x,y)
+Returns true when x is equal to y.
+Note: This function only looks at the first two numbers entered in this function.
+
+```
+EQUALS(1,1) 
+=> true
+
+EQUALS(1,2) 
+=> false
+
+EQUALS(1,1,5)
+=> true
+```
+
+#### NOT
+Returns true when x is not equal to y.
+Note: This function only looks at the first two numbers entered in this function.
+
+```
+NOT(1,1) 
+=> false
+
+NOT(1,2) 
+=> true
+
+NOT(1,1,5)
+=> false
+```
+
+#### OR
+#### TODO
+
+#### IS_NUMBER(x)
+Returns true when x is a number.
+Note: The number is only recognized when placed in brackets.
+Furthermore it only looks at the first element inside the brackets.
+While not using brackets, the function will expect one element.
+
+```
+IS_NUMBER(1) 
+=> Error
+
+IS_NUMBER([3]) 
+=> true
+
+IS_NUMBER('three') 
+=> false
+
+IS_NUMBER([3,'three']) 
+=> true
+
+IS_NUMBER([3],'three')
+=> Error: Wrong number of elements
+```
+
+#### IS_NIL
+#### TODO
+Don't know a good true use case for this.
+
+#### NEG(x)
+Returns the first value but negative.
+
+```
+NEG(5) 
+=> 5
+
+NEG(5) 
+=> -5
+#### UNIT
+
+#### INVERSE
+
+#### FLATTEN
+
+#### flatten_compact
+
+#### flatten_uniq
+
+# Lookup
+
+QUERY_PRESENT
+
+QUERY_FUTURE
+
+QUERY_DELTA
+
+MIXED
+
+GRAPH
+
+ALL
+
+GROUP
+
+MGROUP
+
+EDGE_GROUP
+
+MEDGE_GROUP
+
+SECTOR
+
+MSECTOR
+
+USE
+
+CARRIER
+
+MCARRIER
+
+AREA
+
+INSULATION_COST
+
+WEATHER_PROPERTY
+
+FEVER_DEMAND
+
+FEVER_PRODUCTION
+
+CURVE_SET_VARIANTS
+
+GOAL
+
+GOAL_IS_SET
+
+GOAL_USER_VALUE
+
+ELEMENT_AT
+
+LAST
+
+FIRST
+
+EDGE
+
+MEDGE
+
+EDGES
+
+OUTPUT_SLOTS
+
+INPUT_SLOTS
+
+INPUT_EDGES
+
+OUTPUT_EDGES
+
+edges_for
+
+edge_between_nodes
+
+# Update
+
+EACH
+
+UPDATE
+
+UPDATE_WITH_FACTOR
+
+UPDATE_ABSOLUTE
+
+update_something_by
+
+update_element_with
+
+USER_INPUT
+
+# Graph Query Language
+
+Made to be able to draw information from the graph. Many types of information can be queried. Ask one of the programmers for a automated version of this page, which is available in the code.
+
+ABS(values, arguments, scope = nil)
+-------------------------------
+@param values [Array] @return [Array] absolute numbers
+
+ALL(keys, arguments, scope)
+---------------------------
+
+All Converters in the graph. Use wisely. @return [Array
+
+AREA(keys, arguments, scope)
+----------------------------
+
+{Qernel::Area Graph} attribute of current country: \*AREA(available\_land)\* @param keys [String] Attribute of area @return [Float]
+
+AVG(values, arguments, scope = nil)
+-------------------------------
+@param values [Array] @return [Float] Average of values (ignoring nil values)
+
+CARRIER(keys, arguments, scope)
+-------------------------------
+
+{Qernel::Carrier Carrier} with the keys: \*CARRIER(electricity)\* @param keys [Array] Carrier key(s) @return [Array]
+
+CHILDREN(converters, arguments, scope)
+--------------------------------------
+
+Children of a converter(s). e.g.
+```
+CHILDREN(V(small_chp_industry_energetic))
+```
+@param converters [String] converters @return [Array] direct children of the converters
+
+COMPARE(values, arguments, scope = nil)
+-------------------------------
+@param values [Float,Float] Two values. @return [-1,0,1]
+
+COUNT(values, arguments, scope = nil)
+-------------------------------
+How many (non-nil) values are there? @param values [Array] @return [Integer] Size of array (ignoring nil values)
+
+DIVIDE(values, arguments, scope = nil)
+-------------------------------
+@param values [Float,Float] @return [Float]
+
+EQUALS(values, arguments, scope = nil)
+-------------------------------
+@param values [Float,Float] @return [Boolean] true if first equals second
+
+EXCLUDE(keys, arguments, scope = nil)
+-------------------------------
+Returns the intersection of two sets of converters. e.g.
+```
+EXCLUDE([dennis,willem,alexander],[dennis])
+=> [willem,alexander]`
+```
+@param keys [Array,Array] @return [Array]
+
+FILTER(converters, filter\_name, scope)
+---------------------------------------
+
+Selects only the converters that return true to the given instance\_evaled ruby string.
+
+FILTER(ALL(); electricity\_input \> 0) @param converters [String] converters
+
+FOR\_COUNTRIES(value\_terms, arguments, scope = nil)
+-------------------------------
+Excecutes statement only if Current.scenario.country is in parameter list. Note: separate countries with “;“ e.g.
+```
+FOR_COUNTRIES(5;de;en;it)
+# if Current.scenario.country is in the parameter list
+=> 5
+=> if not.
+=> nil
+```
+G(keys, arguments, scope)
+-------------------------
+
+Alias for: GROUP
+
+GOAL(key)
+---------
+
+Returns the GOAL object with the \`key\name. The only important attribute of the GOAL object is \`user\_value\`.
+```
+  UPDATE(GOAL(foobar),user_value,123)
+```
+You can get that value back with
+```
+ V(GOAL(foobar);user_value)
+```
+or with the shortcut
+```
+  GOAL_USER_VALUE(foobar)
+```
+
+If the user didn't set any value then user\_value will be nil. To check if the user has set a value you can use
+```
+   GOAL_IS_SET(foobar)
+```
+that will return a boolean.
+
+GRAPH(keys, arguments, scope)
+-----------------------------
+
+{Qernel::GraphApi Graph} attributes: \*GRAPH(method)\* @see Qernel::GraphApi @param keys [String] GraphApi method @return [Float]
+
+GREATER(values, arguments, scope = nil)
+-------------------------------
+GREATER(2,1) =\> true @param values [Float,Float] @return [Boolean] true if first is greater then second
+
+GREATER\_OR\_EQUAL(values, arguments, scope = nil)
+-------------------------------
+@param values [Float,Float] @return [Boolean] true if first is greater or equal then second
+
+GROUP(keys, arguments, scope)
+-----------------------------
+
+Converters of a {Qernel::Group Group}: \*GROUP(primary\_demand\_cbs)\* @param keys [Array] Group key(s) @return [Array] Also aliased as: G
+
+IF(value\_terms, arguments, scope = nil)
+-------------------------------
+If statement, with a check clause (condition) and two values.
+```
+IF( condition , value if true , value if false )
+```
+e.g.
+```
+s
+=> 0
+IF(LESS(1,3),IF(LESS(3,1),50,10),100)
+=> 10
+```
+@param statements [Array] Expects 3 statements: condition, value if true, value if false @raise [GqlError] if condition statement is not boolean @raise [GqlError] if arguments does not contain 3 statements @return [Object]
+
+INTERSECTION(keys, arguments, scope = nil)
+-------------------------------
+Returns the intersection of two sets of converters. e.g.
+```
+INTERSECTION([dennis,willem,alexander],[sebastian,dennis,willem])
+=> [dennis,willem]
+```
+It is mostly used to get an intersection of a group and a sector: e.g.
+```
+INTERSECTION(GROUP(heat_production),SECTOR(industry))
+```
+Note that it only works with two arguments. Bad:
+```
+INTERSECTION(GROUP(team_members),dennis,willem)
+```
+Good:
+```
+INTERSECTION(GROUP(team_members),V(dennis,willem))
+```
+@param keys [Array,Array] Intersection of two converter arrays @return [Array]
+
+NVALID\_TO\_ZERO(values, arguments, scope = nil)
+-------------------------------
+converts nil and NaN values to zero values @param values [Float,Array] @return [Float,Array] Array with nil or NaN values converted to zero
+
+INVERSE(values, arguments, scope = nil)
+-------------------------------
+@param values [Float] @return [Float] 1 / x of value
+
+IS\_NIL(value, arguments, scope = nil)
+-------------------------------
+checks if value is nil @param value [Float] @return [Boolean] Is the argument a numeric
+
+IS\_NUMBER(value, arguments, scope = nil)
+-------------------------------
+Is the value a number (and not nil or s’thing else). @param value [Float] @return [Boolean] Is the argument a numeric
+
+LESS(values, arguments, scope = nil)
+-------------------------------
+LESS(1,2) =\> true LESS(1,1) =\> false @param values [Float,Float] @return [Boolean] true if first is less then second
+
+LESS\_OR\_EQUAL(values, arguments, scope = nil)
+-------------------------------
+LESS\_OR\_EQUAL(1,1) =\> true @param values [Float,Float] @return [Boolean] true if first is less or equal then second
+
+MAX(values, arguments, scope = nil)
+-------------------------------
+@param values [Array] @return [Float] the highest number
+
+MIN(values)
+-----------
+
+@param values [Array] @return [Float] the lowest number
+
+MIXED(q1,q2)
+------------
+
+This will run two different queries, one for the present and one for the future graph. This is mainly used for chart series.
+
+NEG(values, arguments, scope = nil)
+-------------------------------
+@param values [Float] @return [Float] -(value)
+
+NIL()
+-----
+
+Returns a nil value. mainly used for testing. e.g.
+NIL()
+```
+NIL\_TO\_ZERO(values, arguments, scope = nil)
+```
+-------------------------------
+convert nil values to zero values @param values [Float,Array] @return [Float,Array] Array with nil values converted to zero
+
+NOT(values, arguments, scope = nil)
+-------------------------------
+@param values [Boolean] @return [Boolean] inverse of values
+
+OR(values, arguments, scope = nil)
+-------------------------------
+@param values [Array] @return [Boolean] Any of the values true?
+
+PARENTS(converters, arguments, scope)
+-------------------------------------
+
+Direct parents of a converter(s). e.g.
+```
+PARENTS(V(small_chp_industry_energetic))
+```
+@param converters [String] converters @return [Array] direct parents of the converters
+
+PRODUCT(values, arguments, scope = nil)
+-------------------------------
+PRODUCT(1,2,3) =\> 1 \* 2 \* 3 =\> 6 @param values [Array] @return [Float] Product of all values (ignoring nil values).
+
+Q(keys, arguments, scope)
+-------------------------
+
+Alias for: QUERY
+
+QUERY(keys, arguments, scope)
+-----------------------------
+
+Executes a subquery with the given key (all stored Gqueries (see /admin/gqueries) can act as subquery): \*QUERY( total\_energy\_cost )\* @param keys [String] The key of the subquery (Gquery) @return The result of the subquery Also aliased as: Q, SUBQUERY
+
+RESCUE(value\_terms, params, scope = nil)
+-------------------------------
+Returns the parameter value (or 0.0 as default) if an error is raised in the value. e.g.
+```
+RESCUE( DIVIDE(NIL(),5))
+=> 0.0`
+# with custom return value
+RESCUE( DIVIDE(NIL(),5); 100.0)
+=> 100.0
+# If no errors returns value
+RESCUE( SUM(1,2); 100.0)
+=> 3.0
+```
+@return [Object] returns the value or the parameter if rescues an exception
+
+SECTOR(keys, arguments, scope)
+------------------------------
+
+Converters of a sector : \*SECTOR(households)\* @see Qernel::Converter::SECTORS list of sectors @param keys [Array] Sector key(s) @return [Array]
+
+SUBQUERY(keys, arguments, scope)
+--------------------------------
+
+@deprecated Alias for: QUERY
+```
+SUM(values, arguments, scope = nil)
+```
+-------------------------------
+Sum of a list of values. @param values [Array] @return [Float] Sum of values (ignoring nil values)
+
+NIT(values, arguments, scope = nil)
+-------------------------------
+Converts a value to another format. Know what you do! Especially useful to write more readable Queries:
+```
+PRODUCT(0.15,100) => 15.0 (%)
+vs.`
+UNIT(0.15;percentage) => 15.0 (%)
+```
+@param values [Float] @return [Float] Converted value
+
+USE(keys, arguments, scope)
+---------------------------
+
+Converters of a “energy use”: energetic, non\_energetic, undefined: \*USE(energetic)\* @see Qernel::Converter::USE list of energy uses @param keys [Array] Use key(s) @return [Array]
+
+V(converters, attribute\_name, scope = nil)
+-------------------------------
+Alias for: VALUE
+
+VALUE(converters, attribute\_name, scope = nil)
+-------------------------------
+VALUE returns the attributes for a set of Converters. Note that duplicate converters are removed, so that
+```
+ VALUE(foo; bar) == VALUE(foo, foo; bar)
+```
+How to use:
+```
+VALUE( list of converters ; attribute )
+More exact:
+VALUE([Array`<Converter>`],[Array`<Converter>`] ; ruby code run inside this objects)
+```
+Getting values form multiple objects
+```
+VALUE(foo,bar,etc; attribute_name)
+=> [3.0,2.0,5.0]
+SUM( VALUE(foo,bar,etc; attribute_name) )
+=> 10.0
+```
+Arbitrary complex select and attribute definition
+```
+VALUE( GROUP(households), GROUP(industry) ; output_demand * -1.5 )
+# translates internally into:
+# VALUE( [households_foo, households_bar], [industry_foo, industry_bar] ; output_demand * - 1.5)
+# translates internally into:
+# VALUE( households_foo, households_bar, industry_foo, industry_bar ; output_demand * - 1.5)
+```
+Special uses Get a value from a carrier We can use the VALUE method also to get values from other objects, mainly CARRIER.
+```
+VALUE( CARRIER(electricity, useable_heat); co2_per_mj )
+```
+Getting values from one object:
+```
+VALUE(foo; attribute_name)
+=> 3.0
+```
+Notice that a Float is returned and not an Array of one Float. This has the advantage that we don’t have to add a SUM-function. Use VALUE to define a collection of converters. Sometimes we want to make a GQL Subquery, that just returns a set of converters. E.g. coal\_plants
+```
+VALUE(foo)
+=> foo
+more complex:
+VALUE( foo, VALUE(foo,bar))
+=> [foo, bar] # Note that foo only appears once. So duplicates are removed
+```
+We can now store the latter query into a Gquery and access them later.
+```
+foo_bar_converters: VALUE( foo, bar )
+SUM( VALUE( Q(foo_bar_converters); demand) )
+```
+@param keys [Array] A list of converters. @param attribute\_name [String] A ruby expression that is instance\_evaled for the selected converters. @return [Array] @return [Array] if no attribute\_name is defined. Also aliased as: V

--- a/docs/contrib/gql.md
+++ b/docs/contrib/gql.md
@@ -128,20 +128,6 @@ DIVIDE(1,2,3,4)
 => 0.5 --> only takes the second.
 ```
 
-#### INVALID_TO_ZERO(keys)
-
-When an invalid value is given, a zero is returned.
-```ruby
-INVALID_TO_ZERO(nil)
-=> 0
-
-INVALID_TO_ZERO(3)
-=> 3
-
-INVALID_TO_ZERO([3,3,nil,4])
-=> [3,3,0,4]
-```
-
 #### MAX(values)
 
 Returns the highest number.

--- a/docs/contrib/gql.md
+++ b/docs/contrib/gql.md
@@ -372,6 +372,7 @@ window_size - The number of points to average over.
 ### Helper functions
 
 #### SORT_BY(*objects, arguments)
+#### SORT_BY(*objects, arguments)
 With SORT_BY nodes can be sorted on one of their attributes.
 The nodes will be sorted ascending to the value of the attribute.
 Ranking of the nodes will start from 0.
@@ -387,6 +388,7 @@ SORT_BY(G(useful_demand),demand)
   ...,
 ]
 ```
+
 
 #### TXT_TABLE(objects, *argyments)
 With TXT_TABLE 1 or more attributes from a node group can be queried.
@@ -432,6 +434,7 @@ TXT_TABLE(SORT_BY(G(useful_demand),demand),key,demand)
 +------------------------------------------------------------------------------+--------------------+
 ```
 
+#### EXCEL_TABLE(objects, *arguments)
 #### EXCEL_TABLE(objects, *arguments)
 Similar functionality to TXT_TABLE
 
@@ -528,11 +531,12 @@ SQRT(4,9)
 SUM(SQRT(4,9)) 
 => 5
 
-### Other functions
+
 
 ```
+### Other functions
 
-### LESS(x,y)
+#### LESS(x,y)
 Returns true when x is smaller than y.
 
 Note: This function only looks at the first two values entered in this function.
@@ -552,7 +556,7 @@ LESS(1,2,5)
 ```
 
 
-### LESS_OR_EQUAL(x,y)
+#### LESS_OR_EQUAL(x,y)
 Returns true when x is smaller or equal than y.
 
 Note: This function only looks at the first two values entered in this function.
@@ -574,7 +578,7 @@ LESS_OR_EQUAL(1,2,5)
 => true
 ```
 
-### GREATER(x,y)
+#### GREATER(x,y)
 Returns true when x is greater than y.
 
 Note: This function only looks at the first two values entered in this function.
@@ -593,7 +597,7 @@ GREATER(2,1,5)
 => true
 ```
 
-### GREATER_OR_EQUAL(x,y)
+#### GREATER_OR_EQUAL(x,y)
 Returns true when x is smaller or equal than y.
 
 Note: This function only looks at the first two values entered in this function.
@@ -615,7 +619,7 @@ GREATER_OR_EQUAL(2,1,5)
 => true
 ```
 
-### EQUALS(x,y)
+#### EQUALS(x,y)
 Returns true when x is equal to y.
 
 Note: This function only looks at the first two values entered in this function.
@@ -631,7 +635,7 @@ EQUALS(1,1,5)
 => true
 ```
 
-### NOT
+#### NOT
 Returns true when x is not equal to y.
 
 Note: This function only looks at the first two values entered in this function.
@@ -647,10 +651,10 @@ NOT(1,1,5)
 => false
 ```
 
-### OR
+#### OR
 todo
 
-### IS_NUMBER(x)
+#### IS_NUMBER(x)
 Returns true when x is a number.
 
 Note: The value is only recognized when placed in brackets.
@@ -674,11 +678,11 @@ IS_NUMBER([3],'three')
 => Error: Wrong number of elements
 ```
 
-### IS_NIL (value)
+#### IS_NIL (value)
 Returns true when the given value is nil. 
 False when the value is not nil.
 
-### NEG(x)
+#### NEG(x)
 Returns the negative value of the given value.
 
 Note: Only the first value is taken into account.
@@ -694,14 +698,14 @@ NEG(-1,-2)
 => 1
 ```
 
-### UNIT(x,unit)
+#### UNIT(x,unit)
 Converts a value to another format.
 ```
 UNIT(0.15,percentage) 
 => 15.0 (%)
 ```
 
-### INVERSE(x)
+#### INVERSE(x)
 Returns the inverse of a given value.
 
 Note: Only the first value is taken into account.
@@ -714,7 +718,7 @@ INVERSE(5,2)
 ```
 
 
-### FLATTEN(array)
+#### FLATTEN(array)
 Flattens any nested arrays into a single array with depth=1, removing nils
 ```
 FLATTEN([[1],[2],[3]])
@@ -723,10 +727,10 @@ FLATTEN([[1],[2],[3]])
 ```
 
 
-### flatten_compact(array)
+#### flatten_compact(array)
 Same functionality as FLATTEN
 
-### flatten_uniq(array)
+#### flatten_uniq(array)
 Same functionality as FLATTEN, removes duplicate values.
 ```
 FLATTEN([[1],[2],[3]])
@@ -741,7 +745,7 @@ FLATTEN([[1],[1],[3]])
 
 
 
-### QUERY_PRESENT(key)
+#### QUERY_PRESENT(key)
 Returns the present value of the the gquery, when given a key.
 
 If the argument is a lambda ( -> { ... }), it returns the present value of the query inside the lamba.
@@ -773,7 +777,7 @@ error
 ```
 
 
-### QUERY_FUTURE(key)
+#### QUERY_FUTURE(key)
 
 Returns the present value of the the gquery, when given a key.
 If the argument is a lambda ( -> { ... }), it returns the present value of the query inside the lamba. 
@@ -803,7 +807,7 @@ QUERY_FUTURE(GRAPH(year))
 error
 ```
 
-### QUERY_DELTA(key)
+#### QUERY_DELTA(key)
 
 Returns the delta of the present value and future value of the query. Note: an operation within this query should be noted inside ( -> { ... }). See examples: 
 ```
@@ -822,11 +826,11 @@ QUERY_DELTA(GRAPH(year))
 error
 ```
 
-### MIXED
+#### MIXED
 TODO
 
 
-### GRAPH(keys)
+#### GRAPH(keys)
 Returns an attribute of a graph:
 keys - the name of the attribute.
 ```
@@ -836,15 +840,15 @@ GRAPH(year)
 2050      2,050
 ```
 
-### ALL
+#### ALL
 Returns an Array of all nodes in the energy graph. #Why is this necesary?
 Can also be found via the engine.
 
-### MALL 
+#### MALL 
 Returns an Array of all nodes in the molecule graph. #Why is this necesary?
 Can also be found via the engine.
 
-### GROUP(group)
+#### GROUP(group)
 
 Returns an Array of all nodes for a given energy group.
 ```
@@ -859,7 +863,7 @@ GROUP(apartments)
   #<Node households_useful_demand_for_space_heating_apartments_future>,
 ]
 ```
-### MGROUP(group)
+#### MGROUP(group)
 Returns an Array of all nodes for a given molecule group.
 ```
 MGROUP(ccu_emitted)
@@ -869,13 +873,13 @@ MGROUP(ccu_emitted)
 ]
 ```
 
-### EDGE_GROUP(group)
+#### EDGE_GROUP(group)
 Deprecated?
 
-### MEDGE_GROUP
+#### MEDGE_GROUP
 Deprecated?
 
-### SECTOR(sector)
+#### SECTOR(sector)
 
 Returns an Array of nodes for a given energy sector
 
@@ -889,7 +893,7 @@ Returns an Array of nodes for a given energy sector
 ]
 ```
 
-### MSECTOR
+#### MSECTOR
 
 Returns an Array of nodes for a given molecule sector
 
@@ -903,7 +907,7 @@ SECTOR(energy)
 ]
 ```
 
-### USE(key)
+#### USE(key)
 
 Returns an Array of nodes for given energy use
 
@@ -917,9 +921,9 @@ USE(energetic)
 ```
 
 
-### CARRIER(key)
+#### CARRIER(key)
 Returns an Array of carriers for given key(s). Returns carriers belonging to the energy graph.
-### Could use some more details on why this is useful.
+#### Could use some more details on why this is useful.
 
 ```
 CARRIER(electricity)
@@ -929,10 +933,10 @@ CARRIER(electricity)
 ]
 ```
 
-### MCARRIER
+#### MCARRIER
 Returns an Array of carriers for given key(s). Returns carriers belonging to the molecule graph. See CARRIER
 
-### AREA
+#### AREA
 Returns an attribute.
 
 Example:
@@ -942,33 +946,33 @@ AREA(present_number_of_residences)
 ```
 
 
-### INSULATION_COST
+#### INSULATION_COST
 TODO; deprecated?
 
-### WEATHER_PROPERTY
+#### WEATHER_PROPERTY
 deprecated?
 
-### FEVER_DEMAND
+#### FEVER_DEMAND
 Useful?
 
-### FEVER_PRODUCTION
+#### FEVER_PRODUCTION
 Useful?
 
-### CURVE_SET_VARIANTS
+#### CURVE_SET_VARIANTS
 
-### GOAL
+#### GOAL
 Deprecated?
 
-### GOAL_IS_SET
+#### GOAL_IS_SET
 Deprecated?
-### GOAL_USER_VALUE
+#### GOAL_USER_VALUE
 Deprecated?
 
 
-### ELEMENT_AT
+#### ELEMENT_AT
 Deprecated
 
-### LAST(values)
+#### LAST(values)
 Returns the last element of the array.
 
 ```
@@ -977,7 +981,7 @@ LAST(V(1,2,3))
 3
 ```
 
-### FIRST(values)
+#### FIRST(values)
 Returns the first element of the array.
 Example:
 ```
@@ -986,7 +990,7 @@ LAST(V(1,2,3))
 1
 ```
 
-### EDGE(lft,rgt)
+#### EDGE(lft,rgt)
 
 Returns the edge that goes from the first (lft) to the second node (rgt) for the energy graph. 
 ```
@@ -996,12 +1000,12 @@ EDGE(energy_import_electricity,energy_interconnector_1_imported_electricity
 #<Qernel::Edge "energy_import_electricity-energy_interconnector_1_imported_electricity@imported_electricity">
 ```
 
-### MEDGE(lft,rgt)
+#### MEDGE(lft,rgt)
 
 Returns the edge that goes from the  first (lft) to the second node (rgt) for the molecule graph. See EDGE() for functionality
 
 
-### EDGES
+#### EDGES
 
 Retrieves edges based on given node(s) and optional arguments to filter or specify the type of edges.
 ```
@@ -1024,7 +1028,7 @@ EDGES(L(foo, bar))
 [Edges of multiple nodes]
 ```
 
-### OUTPUT_SLOTS
+#### OUTPUT_SLOTS
 Gets the output (to the left) slots of node(s). Can specify a particular type of slot or retrieve all output slots.
 ```
 OUTPUT_SLOTS(foo)
@@ -1044,7 +1048,7 @@ OUTPUT_SLOTS(foo, loss)
 [(loss)-foo]
 ```
 
-### INPUT_SLOTS
+#### INPUT_SLOTS
 
 Gets the input (to the right) slots of node(s). Can specify a particular type of slot or retrieve all input slots.
 Examples:
@@ -1059,7 +1063,7 @@ INPUT_SLOTS(foo, gas)
 [foo-(gas)]
 ```
 
-### INPUT_EDGES
+#### INPUT_EDGES
 INPUT_EDGES(value_terms, arguments = nil)
 Retrieves input edges based on given node(s) and optional arguments to filter or specify the type of edges.
 Examples:
@@ -1083,7 +1087,7 @@ INPUT_EDGES(L(foo, bar))
 [Input edges of multiple nodes]
 ```
 
-### OUTPUT_EDGES
+#### OUTPUT_EDGES
 Retrieves output edges based on given node(s) and optional arguments to filter or specify the type of edges.
 ```
 OUTPUT_EDGES(L(foo))
@@ -1107,7 +1111,7 @@ OUTPUT_EDGES(L(foo, bar))
 
 
 
-### EACH
+#### EACH
 Runs multiple (update) queries.
 Example:
 ```
@@ -1120,7 +1124,7 @@ EACH(
 
 ```
 
-### UPDATE
+#### UPDATE
 Updates attributes or elements based on the specified conditions or inputs, with various strategies (absolute, relative_total, or relative_per_year).
 
 ```
@@ -1133,7 +1137,7 @@ UPDATE(L(foo, bar, baz), demand, 5)
 Demand of all nodes becomes 5
 
 ```
-### UPDATE_WITH_FACTOR
+#### UPDATE_WITH_FACTOR
 Same as UPDATE, but the input value is expected to be a factor that the user supplies.
 Example:
 ```
@@ -1143,7 +1147,7 @@ Foo gets a demand of 110.0
 
 ```
 
-### UPDATE_ABSOLUTE
+#### UPDATE_ABSOLUTE
 Same as UPDATE, but forcefully behaving as the absolute strategy.
 Example:
 ```
@@ -1153,7 +1157,7 @@ Demand of foo becomes 500
 
 ```
 
-### USER_INPUT
+#### USER_INPUT
 Retrieves the numeric value of the user input, handling different formats (absolute, percentage, etc.).
 Example:
 ```
@@ -1162,7 +1166,7 @@ USER_INPUT()
 3.0 (if the user input is "3")
 ```
 
-### INPUT_VALUE(key)
+#### INPUT_VALUE(key)
 Retrieves the value of a specified input.
 Example:
 ```
@@ -1171,7 +1175,7 @@ INPUT_VALUE('agriculture_geothermal_share')
 0.104
 ```
 
-### UPDATE_OBJECT()
+#### UPDATE_OBJECT()
 Accesses the currently updated object in the context of an UPDATE statement.
 Example:
 ```
@@ -1181,7 +1185,7 @@ UPDATE(L(foo, bar), demand, -> {V(UPDATE_OBJECT(), demand) + USER_INPUT()})
 
 ```
 
-### UPDATE_COLLECTION()
+#### UPDATE_COLLECTION()
 Accesses all objects in the current UPDATE statement.
 Example:
 ```
@@ -1191,349 +1195,3 @@ UPDATE(L(foo, bar, baz), demand, -> {
 =>
 [Updates demands of foo, bar, baz with the remainder]
 ```
-# Old documenatation 
-
-
-Made to be able to draw information from the graph. Many types of information can be queried. Ask one of the programmers for a automated version of this page, which is available in the code.
-
-### ABS(values, arguments, scope = nil)
--------------------------------
-@param values [Array] @return [Array] absolute numbers
-
-### ALL(keys, arguments, scope)
----------------------------
-
-All Converters in the graph. Use wisely. @return [Array
-
-### AREA(keys, arguments, scope)
-----------------------------
-
-{Qernel::Area Graph} attribute of current country: \*AREA(available\_land)\* @param keys [String] Attribute of area @return [Float]
-
-### AVG(values, arguments, scope = nil)
--------------------------------
-@param values [Array] @return [Float] Average of values (ignoring nil values)
-
-### CARRIER(keys, arguments, scope)
--------------------------------
-
-{Qernel::Carrier Carrier} with the keys: \*CARRIER(electricity)\* @param keys [Array] Carrier key(s) @return [Array]
-
-### CHILDREN(converters, arguments, scope)
---------------------------------------
-
-Children of a converter(s). e.g.
-```
-CHILDREN(V(small_chp_industry_energetic))
-```
-@param converters [String] converters @return [Array] direct children of the converters
-
-### COMPARE(values, arguments, scope = nil)
--------------------------------
-@param values [Float,Float] Two values. @return [-1,0,1]
-
-### COUNT(values, arguments, scope = nil)
--------------------------------
-How many (non-nil) values are there? @param values [Array] @return [Integer] Size of array (ignoring nil values)
-
-### DIVIDE(values, arguments, scope = nil)
--------------------------------
-@param values [Float,Float] @return [Float]
-
-### EQUALS(values, arguments, scope = nil)
--------------------------------
-@param values [Float,Float] @return [Boolean] true if first equals second
-
-### EXCLUDE(keys, arguments, scope = nil)
--------------------------------
-Returns the intersection of two sets of converters. e.g.
-```
-EXCLUDE([dennis,willem,alexander],[dennis])
-=> [willem,alexander]`
-```
-@param keys [Array,Array] @return [Array]
-
-### FILTER(converters, filter\_name, scope)
----------------------------------------
-
-Selects only the converters that return true to the given instance\_evaled ruby string.
-
-FILTER(ALL(); electricity\_input \> 0) @param converters [String] converters
-
-### FOR\_COUNTRIES(value\_terms, arguments, scope = nil)
--------------------------------
-Excecutes statement only if Current.scenario.country is in parameter list. Note: separate countries with “;“ e.g.
-```
-FOR_COUNTRIES(5;de;en;it)
-# if Current.scenario.country is in the parameter list
-=> 5
-=> if not.
-=> nil
-```
-### G(keys, arguments, scope)
--------------------------
-
-Alias for: GROUP
-
-### GOAL(key)
----------
-
-Returns the GOAL object with the \`key\name. The only important attribute of the GOAL object is \`user\_value\`.
-```
-  UPDATE(GOAL(foobar),user_value,123)
-```
-You can get that value back with
-```
- V(GOAL(foobar);user_value)
-```
-or with the shortcut
-```
-  GOAL_USER_VALUE(foobar)
-```
-
-If the user didn't set any value then user\_value will be nil. To check if the user has set a value you can use
-```
-   GOAL_IS_SET(foobar)
-```
-that will return a boolean.
-
-
-### GRAPH(keys, arguments, scope)
------------------------------
-
-{Qernel::GraphApi Graph} attributes: \*GRAPH(method)\* @see Qernel::GraphApi @param keys [String] GraphApi method @return [Float]
-
-### GREATER(values, arguments, scope = nil)
--------------------------------
-GREATER(2,1) =\> true @param values [Float,Float] @return [Boolean] true if first is greater then second
-
-### GREATER\_OR\_EQUAL(values, arguments, scope = nil)
--------------------------------
-@param values [Float,Float] @return [Boolean] true if first is greater or equal then second
-
-### GROUP(keys, arguments, scope)
------------------------------
-
-Converters of a {Qernel::Group Group}: \*GROUP(primary\_demand\_cbs)\* @param keys [Array] Group key(s) @return [Array] Also aliased as: G
-
-### IF(value\_terms, arguments, scope = nil)
--------------------------------
-If statement, with a check clause (condition) and two values.
-```
-IF( condition , value if true , value if false )
-```
-e.g.
-```
-s
-=> 0
-IF(LESS(1,3),IF(LESS(3,1),50,10),100)
-=> 10
-```
-@param statements [Array] Expects 3 statements: condition, value if true, value if false @raise [GqlError] if condition statement is not boolean @raise [GqlError] if arguments does not contain 3 statements @return [Object]
-
-### INTERSECTION(keys, arguments, scope = nil)
--------------------------------
-Returns the intersection of two sets of converters. e.g.
-```
-INTERSECTION([dennis,willem,alexander],[sebastian,dennis,willem])
-=> [dennis,willem]
-```
-It is mostly used to get an intersection of a group and a sector: e.g.
-```
-INTERSECTION(GROUP(heat_production),SECTOR(industry))
-```
-Note that it only works with two arguments. Bad:
-```
-INTERSECTION(GROUP(team_members),dennis,willem)
-```
-Good:
-```
-INTERSECTION(GROUP(team_members),V(dennis,willem))
-```
-@param keys [Array,Array] Intersection of two converter arrays @return [Array]
-
-### INVALID\_TO\_ZERO(values, arguments, scope = nil)
--------------------------------
-converts nil and NaN values to zero values @param values [Float,Array] @return [Float,Array] Array with nil or NaN values converted to zero
-
-### INVERSE(values, arguments, scope = nil)
--------------------------------
-@param values [Float] @return [Float] 1 / x of value
-
-### IS\_NIL(value, arguments, scope = nil)
--------------------------------
-checks if value is nil @param value [Float] @return [Boolean] Is the argument a numeric
-
-### IS\_NUMBER(value, arguments, scope = nil)
--------------------------------
-Is the value a number (and not nil or s’thing else). @param value [Float] @return [Boolean] Is the argument a numeric
-
-### LESS(values, arguments, scope = nil)
--------------------------------
-### LESS(1,2) =\> true LESS(1,1) =\> false @param values [Float,Float] @return [Boolean] true if first is less then second
-
-### LESS\_OR\_EQUAL(values, arguments, scope = nil)
--------------------------------
-LESS\_OR\_EQUAL(1,1) =\> true @param values [Float,Float] @return [Boolean] true if first is less or equal then second
-
-### MAX(values, arguments, scope = nil)
--------------------------------
-@param values [Array] @return [Float] the highest number
-
-### MIN(values)
------------
-
-@param values [Array] @return [Float] the lowest number
-
-### MIXED(q1,q2)
-------------
-
-This will run two different queries, one for the present and one for the future graph. This is mainly used for chart series.
-
-### NEG(values, arguments, scope = nil)
--------------------------------
-@param values [Float] @return [Float] -(value)
-
-### NIL()
------
-
-Returns a nil value. mainly used for testing. e.g.
-NIL()
-```
-NIL\_TO\_ZERO(values, arguments, scope = nil)
-```
--------------------------------
-convert nil values to zero values @param values [Float,Array] @return [Float,Array] Array with nil values converted to zero
-
-### NOT(values, arguments, scope = nil)
--------------------------------
-@param values [Boolean] @return [Boolean] inverse of values
-
-OR(values, arguments, scope = nil)
--------------------------------
-@param values [Array] @return [Boolean] Any of the values true?
-
-### PARENTS(converters, arguments, scope)
--------------------------------------
-
-Direct parents of a converter(s). e.g.
-```
-PARENTS(V(small_chp_industry_energetic))
-```
-@param converters [String] converters @return [Array] direct parents of the converters
-
-### PRODUCT(values, arguments, scope = nil)
--------------------------------
-PRODUCT(1,2,3) =\> 1 \* 2 \* 3 =\> 6 @param values [Array] @return [Float] Product of all values (ignoring nil values).
-
-### Q(keys, arguments, scope)
--------------------------
-
-Alias for: QUERY
-
-### QUERY(keys, arguments, scope)
------------------------------
-
-Executes a subquery with the given key (all stored Gqueries (see /admin/gqueries) can act as subquery): \*QUERY( total\_energy\_cost )\* @param keys [String] The key of the subquery (Gquery) @return The result of the subquery Also aliased as: Q, SUBQUERY
-
-### RESCUE(value\_terms, params, scope = nil)
--------------------------------
-Returns the parameter value (or 0.0 as default) if an error is raised in the value. e.g.
-```
-RESCUE( DIVIDE(NIL(),5))
-=> 0.0`
-# with custom return value
-RESCUE( DIVIDE(NIL(),5); 100.0)
-=> 100.0
-# If no errors returns value
-RESCUE( SUM(1,2); 100.0)
-=> 3.0
-```
-@return [Object] returns the value or the parameter if rescues an exception
-
-### SECTOR(keys, arguments, scope)
-------------------------------
-
-Converters of a sector : \*SECTOR(households)\* @see Qernel::Converter::SECTORS list of sectors @param keys [Array] Sector key(s) @return [Array]
-
-### SUBQUERY(keys, arguments, scope)
---------------------------------
-
-@deprecated Alias for: QUERY
-```
-### SUM(values, arguments, scope = nil)
-```
--------------------------------
-Sum of a list of values. @param values [Array] @return [Float] Sum of values (ignoring nil values)
-
-### UNIT(values, arguments, scope = nil)
--------------------------------
-Converts a value to another format. Know what you do! Especially useful to write more readable Queries:
-```
-PRODUCT(0.15,100) => 15.0 (%)
-vs.`
-UNIT(0.15;percentage) => 15.0 (%)
-```
-@param values [Float] @return [Float] Converted value
-
-### USE(keys, arguments, scope)
----------------------------
-
-Converters of a “energy use”: energetic, non\_energetic, undefined: \*USE(energetic)\* @see Qernel::Converter::USE list of energy uses @param keys [Array] Use key(s) @return [Array]
-
-### V(converters, attribute\_name, scope = nil)
--------------------------------
-Alias for: VALUE
-
-### VALUE(converters, attribute\_name, scope = nil)
--------------------------------
-VALUE returns the attributes for a set of Converters. Note that duplicate converters are removed, so that
-```
- VALUE(foo; bar) == VALUE(foo, foo; bar)
-```
-How to use:
-```
-VALUE( list of converters ; attribute )
-More exact:
-VALUE([Array`<Converter>`],[Array`<Converter>`] ; ruby code run inside this objects)
-```
-Getting values form multiple objects
-```
-VALUE(foo,bar,etc; attribute_name)
-=> [3.0,2.0,5.0]
-SUM( VALUE(foo,bar,etc; attribute_name) )
-=> 10.0
-```
-Arbitrary complex select and attribute definition
-```
-VALUE( GROUP(households), GROUP(industry) ; output_demand * -1.5 )
-# translates internally into:
-# VALUE( [households_foo, households_bar], [industry_foo, industry_bar] ; output_demand * - 1.5)
-# translates internally into:
-# VALUE( households_foo, households_bar, industry_foo, industry_bar ; output_demand * - 1.5)
-```
-Special uses Get a value from a carrier We can use the VALUE method also to get values from other objects, mainly CARRIER.
-```
-VALUE( CARRIER(electricity, useable_heat); co2_per_mj )
-```
-Getting values from one object:
-```
-VALUE(foo; attribute_name)
-=> 3.0
-```
-Notice that a Float is returned and not an Array of one Float. This has the advantage that we don’t have to add a SUM-function. Use VALUE to define a collection of converters. Sometimes we want to make a GQL Subquery, that just returns a set of converters. E.g. coal\_plants
-```
-VALUE(foo)
-=> foo
-more complex:
-VALUE( foo, VALUE(foo,bar))
-=> [foo, bar] # Note that foo only appears once. So duplicates are removed
-```
-We can now store the latter query into a Gquery and access them later.
-```
-foo_bar_converters: VALUE( foo, bar )
-SUM( VALUE( Q(foo_bar_converters); demand) )
-```
-@param keys [Array] A list of converters. @param attribute\_name [String] A ruby expression that is instance\_evaled for the selected converters. @return [Array] @return [Array] if no attribute\_name is defined. Also aliased as: V
-
-

--- a/docs/contrib/gql.md
+++ b/docs/contrib/gql.md
@@ -1,66 +1,37 @@
 ---
-title: Graph Query Language (GQL)
+title: Graph query language (GQL)
 ---
 
+GQL is used to calculate values that are used in the graphs, tables and figures that can be viewed in the model. Users can check values themselves by using the GQL-sandbox in ETEngine. {TO DO: update}
 
+## Writing gqueries
 
-# General information GQL
+Please note that the output that is printed in this documentation is dependent on the scenario the user is using. GQL is case sensitive. Since all GQL-functions are written in caps, this means that all functions **must** be written in caps in order to function. {TO DO: update}
 
-GQL is used to calculate values that are used in the graphs, tables and figures that can be viewed in the model. Users can check values themselves by using the GQL-sandbox in ETEngine. This can be found here --> [Link]
+##  Constants
 
+```ruby
+MWH_TO_GJ = 3.6
+MONTHS_PER_YEAR = 12.0
+HOURS_PER_YEAR = 8760.0
+SECS_PER_HOUR = 3600.0
+SECS_PER_YEAR = SECS_PER_HOUR * HOURS_PER_YEAR
+KG_PER_TONNE = 1000
+LITER_PER_BARREL = 159
+MJ_TO_MHW = 3600
+MJ_PER_KWH = 3.6
+MJ_PER_MWH = 3600
+BILLIONS = 10.0**9
+MJ_TO_PJ = BILLIONS
+MILLIONS = 10.0**6
+THOUSANDS = 1000.0
+```
 
-Please note that the output that is printed in this documentation is dependent on the scenario the user is using. 
+##  Functions
 
-GQL is case sensitive. Since all GQL-functions are written in caps, this means that all functions **must** be written in caps in order to function.
+### Aggregate functions
 
-
-##  Constants:
-
-### MWH_TO_GJ = 3.6
-
-### HOURS_PER_YEAR = 8760.0
-
-### MAN_HOURS_PER_MAN_YEAR = 1800.0
-
-### MAN_YEAR_PER_MJ_INSULATION_PER_YEAR = 0.0000000122916
-
-### SECS_PER_HOUR = 3600.0
-
-### SECS_PER_YEAR = SECS_PER_HOUR * HOURS_PER_YEAR
-
-### KG_PER_TONNE = 1000
-
-### LITER_PER_BARREL = 159
-
-### MJ_TO_MHW = 3600
-
-### MJ_PER_KWH = 3.6
-
-### MJ_PER_MWH = 3600
-
-### BILLIONS = 10.0**9
-
-### MJ_TO_PJ = BILLIONS
-
-### MILLIONS = 10.0**6
-
-### THOUSANDS = 1000.0
-
-### #NIL = nil if !defined?(NIL)
-
-### EURO_SIGN = '&euro;'
-
-### MONTHS_PER_YEAR = 12.0
-
-### INFINITY = Float::INFINITY
-
-
-# List of all functions:
-
-
-## Functions to be categorized
-
-### COUNT(values)
+#### COUNT(values)
 
 Returns how many values. Removes nil values, but does not remove duplicates. 
 
@@ -92,7 +63,7 @@ COUNT(L(foo,bar,foo))
 => 2
 ```
 
-### NEG(values)
+#### NEG(values)
 
 Returns the *first* number as a negative
 
@@ -119,7 +90,7 @@ AVG(1,nil,nil,2)
 => 1.5
 ```
 
-### SUM
+#### SUM
 Returns the sum of all numbers (ignores nil values).
 ```
 SUM(1,2) 
@@ -128,7 +99,7 @@ SUM(1,nil)
 => 1
 ```
 
-### PRODUCT(values)
+#### PRODUCT(values)
 
 Multiplies all numbers (ignores nil values).
 
@@ -141,7 +112,7 @@ PRODUCT(1,nil)
 ```
 
 
-### DIVIDE(values)
+#### DIVIDE(values)
 
 Divides the first value with the second value.
 ```
@@ -152,11 +123,9 @@ DIVIDE(1,2,3,4)
 => 0.5 --> only takes the second.
 ```
 
+### Control functions
 
-
-
-
-### EQUALS(values)
+#### EQUALS(values)
 
 Checks if the **first two** values that are given are equal.
 
@@ -174,7 +143,7 @@ EQUALS(2,3,3)
 => false
 ```
 
-### IF(condition, true_stmt, false_stmt)
+#### IF(condition, true_stmt, false_stmt)
 If the condition is true, the true_stmt is returned, if the condition is false, the false_stmt is retunred. 
 ```
 IF(EQUALS(1,1),3,4) 
@@ -184,9 +153,9 @@ IF(EQUALS(1,2),3,4)
 => 4 --> EQUALS(1,2) returns 'false', so 4 is returned.
 ```
 
+### Core functions
 
-
-### V(args)
+#### V(args)
 
 Shortcut for the LOOKUP and MAP function. Also see LOOKUP() and MAP().
 Used to retrieve information from the energy graph.
@@ -220,15 +189,15 @@ Example pass objects to V()
 V(CARRIER(electricity), cost_per_mj) --> = MAP( LOOKUP(CARRIER(electricity)), cost_per_mj )
 => 23.3
 ```
-### VALUE(args)
+#### VALUE(args)
 
 Alias for V()
 
-### MV(args)
+#### MV(args)
 
 Same functionalities as V, but used for the molecule graph. 
 
-### Q(key)
+#### Q(key)
 
 QUERY() or Q() returns the result of a gquery with given key.
 
@@ -239,12 +208,11 @@ Q(total_costs)
 => 100
 ```
 
-### Query(key)
+#### Query(key)
 
 Alias for Q()
 
-
-### Lookup(keys)
+#### Lookup(keys)
 
 lookup energy graph objects by their corresponding key(s).
 keys - Provided keys should be energy graph node keys or Qernel objects 
@@ -279,17 +247,17 @@ LOOKUP(foo, Lookup(foo))
 => [Node(foo)]
 ```
 
-### L(keys)
+#### L(keys)
 Alias for Lookup
 
-### ML(keys)
+#### ML(keys)
 
 Lookup or L for the moleculegraph, alias for MLOOKUP
 
-### MLOOKUP(keys)
+#### MLOOKUP(keys)
 Lookup or L for the moleculegraph, alias for ML.
 
-### MAP(elements, attr_name)
+#### MAP(elements, attr_name)
 
 Access attributes of one or more objects.
 
@@ -327,40 +295,40 @@ MAP(L(foo), 'demand * (3.0 + free_co2_factor)')
 MAP(L(foo), primary_demand_of(CARRIER(electricity)))
 ```
 
-
-### M(elements,attr_name)
+#### M(elements,attr_name)
 
 ALIAS for MAP
 
-### GET(keys)
+#### GET(keys)
 
 Retrieves the attribute from one single object, similar to MAP.
 
+### Curves functions
 
-
-### ATTACHED_CURVE(name)
+#### ATTACHED_CURVE(name)
 
 Looks up the attachment matching the `name`, and converts the contents into a curve. If no attachment is set, nil is returned.
 
-### CLAMP_CURVE(curve, min, max)
+#### CLAMP_CURVE(curve, min, max)
 
 Restricts the values in a curve to be between the minimum and maximum. Raises an error if min > max.
 
-### COALESCE_CURVE(curve, default = 0.0, length = 8760)
+#### COALESCE_CURVE(curve, default = 0.0, length = 8760)
 
 If the given `curve` is an array of non-zero length, it is returned. If the curve is nil or empty, a new curve of `length` length is created, with each value set to `default`.
 
-### CUMULATIVE_CURVE(curve)
+#### CUMULATIVE_CURVE(curve)
 
 Creates a new curve where each index (n) is the sum of (0..n) in the source curve.
 
 
-### INVERT_CURVE(curve)
+#### INVERT_CURVE(curve)
 
 Inverts a single curve by swapping positive numbers to be negative, and vice-versa.
 
-### SUM_CURVES(*curves)
+#### SUM_CURVES(*curves)
 Adds the values in multiple curves.
+
 
 Example:
 
@@ -372,8 +340,7 @@ SUM_CURVES([[1, 2], [3, 4]])
 => [4, 6]
 ```
 
-
-### PRODUCT_CURVES(left,right)
+#### PRODUCT_CURVES(left,right)
 Multiplies two curves elementwise.
 Note that unlike `SUM_CURVES`, `PRODUCT_CURVES` expects exactly two arguments, each one a curve.
 An error will be raised if either parameter is an array of curves, or if the curves don't have matching lengths.
@@ -384,7 +351,7 @@ PRODUCT_CURVES([1, 2, 3], [4, 5, 6])
 => [4, 10, 18]
 ```
 
-### DIVIDE_CURVES(left, right)
+#### DIVIDE_CURVES(left, right)
 Divides two curves elementwise.
 Note that unlike `SUM_CURVES`, `PRODUCT_CURVES` expects exactly two arguments, each one a curve.
 An error will be raised if either parameter is an array of curves, or if the curves don't have matching lengths.
@@ -393,12 +360,12 @@ DIVIDE_CURVES([1, 2, 3], [4, 5, 6])
 => [0.25, 0.4, 0.5]
 ```
 
-### SMOOTH_CURVE(curve, window_size)
+#### SMOOTH_CURVE(curve, window_size)
 Creates a smoothed curve using a moving average.
 curve       - An array of numbers.
 window_size - The number of points to average over.
 
-
+### Helper functions
 
 ### SORT_BY(*objects, arguments)
 With SORT_BY nodes can be sorted on one of their attributes.
@@ -466,8 +433,9 @@ TXT_TABLE(SORT_BY(G(useful_demand),demand),key,demand)
 Similar functionality to TXT_TABLE
 
 
+### Legacy functions
 
-### FILTER(collection, filter)
+#### FILTER(collection, filter)
 Imposes a filter.
 
 Can be used to impose a filter on node groups based on node attributes, see example.
@@ -482,13 +450,13 @@ FILTER(G(electricity_production),"geothermal_input_conversion > 0.0")
 ]
 ```
 
-### CHILDREN(*nodes)
+#### CHILDREN(*nodes)
 todo
 
-### PARENTS(*nodes)
+#### PARENTS(*nodes)
 todo
 
-### INTERSECTION(*keys)
+#### INTERSECTION(*keys)
 Returns the elements that are present in both the first and second arrays.
 
 ```
@@ -496,56 +464,56 @@ INTERSECTION( V(1,2,3) , V(2,3,4) )
 => [2, 3]
 ```
 
-### EXCLUDE(*keys)
+#### EXCLUDE(*keys)
 Returns an Array of elements of the first array excluding the second array.
 ```
 EXCLUDE( V(1,2,3) , V(2,3,4) )
 => [1]
 ```
-### INVALID_TO_ZERO(*keys)
+#### INVALID_TO_ZERO(*keys)
 Deprecated?
 
-### MAX(*values)
+#### MAX(*values)
 Returns the highest number.
 ```
 MAX(-3,-2,5)
 => 5
 ```
-### MIN(*values)
+#### MIN(*values)
 Returns the lowest number.
 ```
 MIN(-3,-2,5)
 => - 3
 ```
-### ABS(*values)
+#### ABS(*values)
 Returns all given numbers in absolute values.
 ```
 ABS(-3,-2,5)
 => [3,2,5]
 ```
 
-### ROUND(value, precision = 0)
+#### ROUND(value, precision = 0)
 Public: Rounds numeric value to a given precision.
 ```
 ROUND(3.334,2)
 => [3.33]
 ```
 
-### FLOOR(value, precision = 0)
+#### FLOOR(value, precision = 0)
 Returns the largest number less than or equal to numeric value.
 ```
 FLOOR(3.5)
 => 3
 ```
 
-### CEIL(value, precision = 0)
+#### CEIL(value, precision = 0)
 Returns the smallest number greater than or equal to numeric value.
 ```
 CEIL(3.5)
 => 4
 ```
 
-### SQRT(*values)
+#### SQRT(*values)
 Returns the square root of the given values.
 ```
 SQRT(4) 
@@ -556,6 +524,9 @@ SQRT(4,9)
 
 SUM(SQRT(4,9)) 
 => 5
+
+### Other functions
+
 ```
 
 ### LESS(x,y)

--- a/docs/contrib/gql.md
+++ b/docs/contrib/gql.md
@@ -919,7 +919,7 @@ Returns an Array of all nodes in the molecule graph.
 
 #### GROUP(group)
 
-Returns an Array of all nodes for a given energy group.
+Returns an Array of all nodes for a given energy graph group.
 
 ```ruby
 GROUP(apartments)
@@ -936,7 +936,7 @@ GROUP(apartments)
 
 #### MGROUP(group)
 
-Returns an Array of all nodes for a given molecule group.
+Returns an Array of all nodes for a given molecule graph group.
 
 ```ruby
 MGROUP(ccu_emitted)
@@ -947,12 +947,21 @@ MGROUP(ccu_emitted)
 ```
 
 #### EDGE_GROUP(group)
+Returns an Array of all nodes for a given energy graph edge group.
 
-TO-DO
+EG(final_demand)
+=>
+[
+  #<Qernel::Edge "agriculture_final_demand_crude_oil-agriculture_burner_crude_oil@crude_oil">,
+  #<Qernel::Edge "agriculture_final_demand_hydrogen-agriculture_burner_hydrogen@hydrogen">,
+  ...,
+  #<Qernel::Edge "transport_final_demand_for_road_lpg-transport_van_using_lpg@lpg">
+]
+```
 
 #### MEDGE_GROUP(group)
+Returns an Array of all nodes for a given energy graph molecul edge group.
 
-TO-DO
 
 #### SECTOR(sector)
 
@@ -1032,21 +1041,109 @@ FILTER(G(electricity_production),"geothermal_input_conversion > 0.0")
 
 These functions concern operations associated with the Fever module.
 
-#### FEVER_DEMAND
-TO-DO
+#### FEVER_DEMAND(groups)
+Outputs the yearly summed demand-curve of the specified fever group.
+The fever groups that can be chosen from are: buildings_space_heating, households_hot_water and space_heating
 
-#### FEVER_PRODUCTION
-TO-DO
-#### FEVER_PRODUCTION_CURVE_FOR_COUPLE
-TO-DO
+```ruby
+FEVER_DEMAND(buildings_space_heating)
+=> 
+[
+  3,863.9766278835864,
+  3,439.1984233894727,
+  ...,
+  6,931.270889166959
+]
 
-#### FEVER_DEMAND_CURVE_FOR_PEOPLE
-TO-DO
+FEVER_DEMAND(households_hot_water)
+=> 
+[
+  0.0,
+  0.0,
+  ...,
+  0.0
+]
 
-#### FEVER_PRODUCTION_CURVE
-TO-DO
-#### FEVER_DEMAND_CURVE
-TO-DO
+FEVER_DEMAND(space_heating)
+=> 
+[
+13,224.03964104562,
+12,848.980134095127,
+...,
+15,208.97143065297
+]
+```
+
+#### FEVER_PRODUCTION(groups)
+
+
+Outputs the yearly summed demand-curve of the specified fever group.
+The fever groups that can be chosen from are: buildings_space_heating, households_hot_water and space_heating
+
+```ruby
+FEVER_PRODUCTION(buildings_space_heating)
+=> 
+[
+  3,863.9766278835864,
+  3,439.1984233894727,
+  ...,
+  6,931.270889166959
+]
+
+FEVER_PRODUCTION(households_hot_water)
+=> 
+[
+  0.0,
+  0.0,
+  ...,
+  0.0
+]
+
+FEVER_PRODUCTION(space_heating)
+=> 
+[
+13,224.03964104562,
+12,848.980134095127,
+...,
+15,208.97143065297
+]
+```
+
+#### FEVER_PRODUCTION_CURVE_FOR_COUPLE(producer,consumer)
+A yearly curve describing the production in MWh of a specific producer for a specific consumer within Fever.
+
+
+
+#### FEVER_DEMAND_CURVE_FOR_COUPLE(producer,consumer)
+A yearly curve describing the demand in MWh of a specific consumer for a specific consumer within Fever.
+
+
+
+#### FEVER_PRODUCTION_CURVE(node)
+A yearly curve describing the production in MWh of/for a specific consumer or producer within Fever.
+```ruby
+FEVER_PRODUCTION_CURVE(V(households_useful_demand_for_space_heating_semi_detached_houses_1985_2004))
+=> 
+[
+  380.84562570105106,
+  ...,
+  462.08107903258804
+]
+```
+
+#### FEVER_DEMAND_CURVE(node)
+A yearly curve describing the demand in MWh of/for a specific consumer or producer within Fever.
+```ruby
+FEVER_DEMAND_CURVE(V(households_useful_demand_for_space_heating_semi_detached_houses_1985_2004))
+=> 
+[
+  380.84562570105106,
+  ...,
+  462.08107903258804
+]
+```
+
+
 
 ### Update functions
 

--- a/docs/contrib/gql.md
+++ b/docs/contrib/gql.md
@@ -1203,6 +1203,7 @@ INPUT_VALUE('agriculture_geothermal_share')
 ```
 
 ### Constants
+The constants are key figures that can be retrieved with GQL.
 
 ```ruby
 MWH_TO_GJ = 3.6

--- a/docs/contrib/gql.md
+++ b/docs/contrib/gql.md
@@ -14,7 +14,7 @@ GQL is case sensitive. Since all GQL-functions are written in caps, this means t
 
 - Base gqueries are added in the `general` folder on [Github](https://github.com/quintel/etsource/tree/master/gqueries/general).
 - Other gqueries, for example gqueries used in `output_elements`, should refer to base gqueries when possible.
-- Base gqueries have a consistent set of base units, for example `MW` for **capacity** and `MJ` for **energy**.
+- Base gqueries have a consistent set of base units, for example `kg` for **emissions**, `MW` for **capacity** and `MJ` for **energy**.
 - Base gqueries have a consistent nomenclature: for example **type**, **subtype**, **sector**, **subsector**, **carrier**.
 - Base gqueries should have a description.
 - To enhance readability, our preferred indentation style for Gqueries involves initially indenting with 4 spaces, followed by an additional 2 spaces for subsequent levels.

--- a/docs/contrib/gql.md
+++ b/docs/contrib/gql.md
@@ -14,26 +14,10 @@ Please note that the output that is printed in this documentation is dependent o
 
 ##  Functions
 
-### Constants
 
-```ruby
-MWH_TO_GJ = 3.6
-MONTHS_PER_YEAR = 12.0
-HOURS_PER_YEAR = 8760.0
-SECS_PER_HOUR = 3600.0
-SECS_PER_YEAR = SECS_PER_HOUR * HOURS_PER_YEAR
-KG_PER_TONNE = 1000
-LITER_PER_BARREL = 159
-MJ_TO_MHW = 3600
-MJ_PER_KWH = 3.6
-MJ_PER_MWH = 3600
-BILLIONS = 10.0**9
-MJ_TO_PJ = BILLIONS
-MILLIONS = 10.0**6
-THOUSANDS = 1000.0
-```
+### Math functions
 
-### Aggregate functions
+The math functions consists of functions that perform mathematical operations or calculations on numerical data. Some example functions are COUNT(), SUM(), DIVIDE() can be found here as well as comparing functions like GREATER() or EQUALS().
 
 #### COUNT(values)
 
@@ -41,7 +25,7 @@ Returns how many values. Removes nil values, but does not remove duplicates.
 
 *Basic example*:
 
-```
+```ruby
 COUNT(1) 
 => 1
 COUNT(1,2)  
@@ -49,21 +33,21 @@ COUNT(1,2)
 ```
 *Node example*:
 
-```
-COUNT(L(foo,bar)) 
+```ruby
+COUNT(V(foo,bar)) 
 => 2
 ```
 
 *multiple LOOKUPS (does not remove duplicates)*
 
-```
-COUNT(L(foo,bar), L(foo)) 
+```ruby
+COUNT(V(foo,bar), V(foo)) 
 => 3
 ```
 
 *Duplicates in one LOOKUP (does remove duplicates)*
-```
-COUNT(L(foo,bar,foo))
+```ruby
+COUNT(V(foo,bar,foo))
 => 2
 ```
 
@@ -73,7 +57,7 @@ Returns the *first* number as a negative
 
 *example*:
 
-```
+```ruby
 NEG(2) 
 => -2
 
@@ -83,7 +67,7 @@ NEG(1,2,3)
 
 #### AVG(values)
 Returns the average of all number (ignores nil values).
-```
+```ruby
 AVG(1,2)    
 => 1.5
 
@@ -96,7 +80,7 @@ AVG(1,nil,nil,2)
 
 #### SUM
 Returns the sum of all numbers (ignores nil values).
-```
+```ruby
 SUM(1,2) 
 => 3
 SUM(1,nil)  
@@ -107,7 +91,7 @@ SUM(1,nil)
 
 Multiplies all numbers (ignores nil values).
 
-```
+```ruby
 PRODUCT(1,2,3)
 =>6 (1*2*3)
 
@@ -119,7 +103,7 @@ PRODUCT(1,nil)
 #### DIVIDE(values)
 
 Divides the first value with the second value.
-```
+```ruby
 DIVIDE(1,2)
 => 0.5
 
@@ -127,401 +111,52 @@ DIVIDE(1,2,3,4)
 => 0.5 --> only takes the second.
 ```
 
-### Control functions
-
-#### EQUALS(values)
-
-Checks if the **first two** values that are given are equal.
-
-```
-EQUALS(2,2)
-=> true
-
-EQUALS(2,3)
-=> false
-
-EQUALS(2,2,3)
-=> true
-
-EQUALS(2,3,3)
-=> false
-```
-
-#### IF(condition, true_stmt, false_stmt)
-If the condition is true, the true_stmt is returned, if the condition is false, the false_stmt is retunred. 
-```
-IF(EQUALS(1,1),3,4) 
-=> 3 --> EQUALS(1,1) returns 'true', so 3 is returned.
-
-IF(EQUALS(1,2),3,4)
-=> 4 --> EQUALS(1,2) returns 'false', so 4 is returned.
-```
-
-### Core functions
-
-#### V(args)
-
-Shortcut for the LOOKUP and MAP function. Also see LOOKUP() and MAP().
-Used to retrieve information from the energy graph.
-
-Example with node
-```
-V(foo) --> LOOKUP(foo)
-=> foo
-```
-
-Example Lookup multiple nodes by their keys
-```
-V(foo,bar) --> LOOKUP(foo,bar)
-=> [<foo>, <bar>]
-```
-
-Example Lookup a node attribute
-```
-V(foo,demand) --> MAP(LOOKUP(foo,demand))
-=> 100 (When demand of node 'foo' is equal to 100)
-```
-
-Example nesting of LOOKUPs
-```
-V(V(foo), V(bar), demand) --> MAP(LOOKUP(foo, LOOKUP(bar)), demand)
-=> 100, 200 
-```
-
-Example pass objects to V()
-```
-V(CARRIER(electricity), cost_per_mj) --> = MAP( LOOKUP(CARRIER(electricity)), cost_per_mj )
-=> 23.3
-```
-#### VALUE(args)
-
-Alias for V()
-
-#### MV(args)
-
-Same functionalities as V, but used for the molecule graph. 
-
-#### Q(key)
-
-QUERY() or Q() returns the result of a gquery with given key.
-
-Example costs
-
-```
-Q(total_costs)
-=> 100
-```
-
-#### Query(key)
-
-Alias for Q()
-
-#### Lookup(keys)
-
-lookup energy graph objects by their corresponding key(s).
-keys - Provided keys should be energy graph node keys or Qernel objects 
-Returns an array of the elements of the query: matching nodes or objects. Duplicates and nil values are removed.
-
-Example 1 or 2 nodes:
-
-```
-LOOKUP(foo)  
-=> [Node(foo)]
-
-LOOKUP(foo, bar) 
-=> [Node(foo), Node(bar)]
-```
-
-Elements that are not node keys are simply returned:
-```
-LOOKUP(foo,3.0)  
-=> [Node(foo),3.0]
-
-LOOKUP(foo, CARRIER(coal)) 
-=> [Node(foo), Carrier(coal)]
-```
-
-nil and duplicate elements are removed:
-
-```
-LOOKUP(foo,nil)  
-=> [Node(foo)]
-
-LOOKUP(foo, Lookup(foo)) 
-=> [Node(foo)]
-```
-
-#### L(keys)
-Alias for Lookup
-
-#### ML(keys)
-
-Lookup or L for the moleculegraph, alias for MLOOKUP
-
-#### MLOOKUP(keys)
-Lookup or L for the moleculegraph, alias for ML.
-
-#### MAP(elements, attr_name)
-
-Access attributes of one or more objects.
-
-=== Single and composed attributes
-
-To query a single attribute simply pass it. You can put it inside '', "" or not.
-
-To join multiple attributes and numbers surround it with "" or ''.
-
-=== GQL functions as arguments
-
-You can pass a GQL function as an argument to a *single* method.
-Attributes dervied from GQL functions cannot be inside "" or ''.
-
-Example with a single attribute:
-```
-MAP(L(foo), demand)
-=> 100
-
-MAP(L(foo), "demand")
-=> 100
-
-MAP(L(foo,bar), demand)
-=> [100, 200]
-```
-
-Example Composed attributes add "" or ''
-
-```
-MAP(L(foo), 'demand * (3.0 + free_co2_factor)')
-=> 100
-```
-
-```
-MAP(L(foo), primary_demand_of(CARRIER(electricity)))
-```
-
-#### M(elements,attr_name)
-
-ALIAS for MAP
-
-#### GET(keys)
-
-Retrieves the attribute from one single object, similar to MAP.
-
-### Curves functions
-
-#### ATTACHED_CURVE(name)
-
-Looks up the attachment matching the `name`, and converts the contents into a curve. If no attachment is set, nil is returned.
-
-#### CLAMP_CURVE(curve, min, max)
-
-Restricts the values in a curve to be between the minimum and maximum. Raises an error if min > max.
-
-#### COALESCE_CURVE(curve, default = 0.0, length = 8760)
-
-If the given `curve` is an array of non-zero length, it is returned. If the curve is nil or empty, a new curve of `length` length is created, with each value set to `default`.
-
-#### CUMULATIVE_CURVE(curve)
-
-Creates a new curve where each index (n) is the sum of (0..n) in the source curve.
-
-
-#### INVERT_CURVE(curve)
-
-Inverts a single curve by swapping positive numbers to be negative, and vice-versa.
-
-#### SUM_CURVES(*curves)
-Adds the values in multiple curves.
-
-
-Example:
-
-```
-SUM_CURVES([1, 2], [3, 4])
-=> [4, 6]
-
-SUM_CURVES([[1, 2], [3, 4]])
-=> [4, 6]
-```
-
-#### PRODUCT_CURVES(left,right)
-Multiplies two curves elementwise.
-Note that unlike `SUM_CURVES`, `PRODUCT_CURVES` expects exactly two arguments, each one a curve.
-An error will be raised if either parameter is an array of curves, or if the curves don't have matching lengths.
-
-Example:
-```
-PRODUCT_CURVES([1, 2, 3], [4, 5, 6])
-=> [4, 10, 18]
-```
-
-#### DIVIDE_CURVES(left, right)
-Divides two curves elementwise.
-Note that unlike `SUM_CURVES`, `PRODUCT_CURVES` expects exactly two arguments, each one a curve.
-An error will be raised if either parameter is an array of curves, or if the curves don't have matching lengths.
-```
-DIVIDE_CURVES([1, 2, 3], [4, 5, 6])
-=> [0.25, 0.4, 0.5]
-```
-
-#### SMOOTH_CURVE(curve, window_size)
-Creates a smoothed curve using a moving average.
-curve       - An array of numbers.
-window_size - The number of points to average over.
-
-### Helper functions
-
-#### SORT_BY(*objects, arguments)
-#### SORT_BY(*objects, arguments)
-With SORT_BY nodes can be sorted on one of their attributes.
-The nodes will be sorted ascending to the value of the attribute.
-Ranking of the nodes will start from 0.
-Note that the value of the attribute will not be printed, see TXT_TABLE for this functionality.
-
-Example with the group 'useful_demand'.
-```
-SORT_BY(G(useful_demand),demand)
-=> 
-[
-  #<Node industry_useful_demand_for_chemical_other_hydrogen_non_energetic> 0,
-  #<Node bunkers_useful_demand_ships> 1,
-  ...,
-]
-```
-
-
-#### TXT_TABLE(objects, *argyments)
-With TXT_TABLE 1 or more attributes from a node group can be queried.
-The nodes in the given node group will be sorted alphabetically.
-
-Within the GQL-sandbox users can choose how the view the table in 4 different modes:
-* Table: Shows the table in standard GQL-sandbox format.
-* Text: Shows the table in text-format.
-* CSV: Shows the table in CSV (comma seperated values) format.
-* TSV: Shows the table in TSV (tab seperated values) format.
-
-Note: With 'key' the name of the node is printed.
-
-Example (output in text format, for readibility only the first 2 and last 2 rows of the table are shown):
-```
-TXT_TABLE(G(useful_demand),key,demand)
-=> 
-+------------------------------------------------------------------------------+--------------------+
-|                                     key                                      |       demand       |
-+------------------------------------------------------------------------------+--------------------+
-| agriculture_useful_demand_electricity                                        | 40964534066.695656 |
-| agriculture_useful_demand_useable_heat                                       | 98697676910.08954  
-|...                                                                           | ...                |
-| transport_useful_demand_trucks                                               | 144749566437.32986 |
-| transport_useful_demand_vans                                                 | 1280922944.4741797 |
-+------------------------------------------------------------------------------+--------------------+
-```
-
-This function can be combined with SORT_BY, so that a quick overview of the nodes with the highest attributes can be found.
-
-Example with SORT_BY (output in text format, for readibility only the first 2 and last 2 rows of the table are shown):
-```
-TXT_TABLE(SORT_BY(G(useful_demand),demand),key,demand)
-=> 
-+------------------------------------------------------------------------------+--------------------+
-|                                     key                                      |       demand       |
-+------------------------------------------------------------------------------+--------------------+
-| industry_useful_demand_for_chemical_other_hydrogen_non_energetic             | 0.0                |
-| bunkers_useful_demand_ships                                                  | 0.0                |
-|...                                                                           | ...                |
-| industry_useful_demand_for_chemical_other_non_energetic                      | 414554538059.73004 |
-| industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic       | 2650973321780.0    |
-+------------------------------------------------------------------------------+--------------------+
-```
-
-#### EXCEL_TABLE(objects, *arguments)
-#### EXCEL_TABLE(objects, *arguments)
-Similar functionality to TXT_TABLE
-
-
-### Legacy functions
-
-#### FILTER(collection, filter)
-Imposes a filter.
-
-Can be used to impose a filter on node groups based on node attributes, see example.
-
-Example:
-
-```
-FILTER(G(electricity_production),"geothermal_input_conversion > 0.0")
-=> 
-[
-  <#Node energy_power_geothermal>,
-]
-```
-
-#### CHILDREN(*nodes)
-todo
-
-#### PARENTS(*nodes)
-todo
-
-#### INTERSECTION(*keys)
-Returns the elements that are present in both the first and second arrays.
-
-```
-INTERSECTION( V(1,2,3) , V(2,3,4) )
-=> [2, 3]
-```
-
-#### EXCLUDE(*keys)
-Returns an Array of elements of the first array excluding the second array.
-```
-EXCLUDE( V(1,2,3) , V(2,3,4) )
-=> [1]
-```
 #### INVALID_TO_ZERO(*keys)
-Deprecated?
+TO-DO
 
 #### MAX(*values)
 Returns the highest number.
-```
+```ruby
 MAX(-3,-2,5)
 => 5
 ```
 #### MIN(*values)
 Returns the lowest number.
-```
+```ruby
 MIN(-3,-2,5)
 => - 3
 ```
 #### ABS(*values)
 Returns all given numbers in absolute values.
-```
+```ruby
 ABS(-3,-2,5)
 => [3,2,5]
 ```
 
 #### ROUND(value, precision = 0)
 Public: Rounds numeric value to a given precision.
-```
+```ruby
 ROUND(3.334,2)
 => [3.33]
 ```
 
 #### FLOOR(value, precision = 0)
 Returns the largest number less than or equal to numeric value.
-```
+```ruby
 FLOOR(3.5)
 => 3
 ```
 
-#### CEIL(value, precision = 0)
+#### CEIV(value, precision = 0)
 Returns the smallest number greater than or equal to numeric value.
-```
-CEIL(3.5)
+```ruby
+CEIV(3.5)
 => 4
 ```
 
 #### SQRT(*values)
 Returns the square root of the given values.
-```
+```ruby
 SQRT(4) 
 => [2]
 
@@ -531,17 +166,15 @@ SQRT(4,9)
 SUM(SQRT(4,9)) 
 => 5
 
-
-
 ```
-### Other functions
+
 
 #### LESS(x,y)
 Returns true when x is smaller than y.
 
 Note: This function only looks at the first two values entered in this function.
 
-```
+```ruby
 LESS(1,2) 
 => true
 
@@ -561,7 +194,7 @@ Returns true when x is smaller or equal than y.
 
 Note: This function only looks at the first two values entered in this function.
 
-```
+```ruby
 LESS_OR_EQUAL(1,2) 
 => true
 
@@ -583,7 +216,7 @@ Returns true when x is greater than y.
 
 Note: This function only looks at the first two values entered in this function.
 
-```
+```ruby
 GREATER(1,2) 
 => false
 
@@ -602,7 +235,7 @@ Returns true when x is smaller or equal than y.
 
 Note: This function only looks at the first two values entered in this function.
 
-```
+```ruby
 GREATER_OR_EQUAL(1,2) 
 => false
 
@@ -624,7 +257,7 @@ Returns true when x is equal to y.
 
 Note: This function only looks at the first two values entered in this function.
 
-```
+```ruby
 EQUALS(1,1) 
 => true
 
@@ -640,7 +273,7 @@ Returns true when x is not equal to y.
 
 Note: This function only looks at the first two values entered in this function.
 
-```
+```ruby
 NOT(1,1) 
 => false
 
@@ -652,7 +285,7 @@ NOT(1,1,5)
 ```
 
 #### OR
-todo
+TO-DO
 
 #### IS_NUMBER(x)
 Returns true when x is a number.
@@ -661,7 +294,7 @@ Note: The value is only recognized when placed in brackets.
 Furthermore it only looks at the first element inside the brackets.
 While not using brackets, the function will expect one element.
 
-```
+```ruby
 IS_NUMBER(1) 
 => Error
 
@@ -687,7 +320,7 @@ Returns the negative value of the given value.
 
 Note: Only the first value is taken into account.
 
-```
+```ruby
 NEG(1) 
 => -1
 
@@ -700,7 +333,7 @@ NEG(-1,-2)
 
 #### UNIT(x,unit)
 Converts a value to another format.
-```
+```ruby
 UNIT(0.15,percentage) 
 => 15.0 (%)
 ```
@@ -709,7 +342,7 @@ UNIT(0.15,percentage)
 Returns the inverse of a given value.
 
 Note: Only the first value is taken into account.
-```
+```ruby
 INVERSE(5)
 => 0.2
 
@@ -720,30 +353,114 @@ INVERSE(5,2)
 
 #### FLATTEN(array)
 Flattens any nested arrays into a single array with depth=1, removing nils
-```
+```ruby
 FLATTEN([[1],[2],[3]])
 =>
 [1,2,3]
 ```
 
+#### EQUALS(values)
 
-#### flatten_compact(array)
-Same functionality as FLATTEN
+Checks if the **first two** values that are given are equal.
 
-#### flatten_uniq(array)
-Same functionality as FLATTEN, removes duplicate values.
+```ruby
+EQUALS(2,2)
+=> true
+
+EQUALS(2,3)
+=> false
+
+EQUALS(2,2,3)
+=> true
+
+EQUALS(2,3,3)
+=> false
 ```
-FLATTEN([[1],[2],[3]])
-=>
-[1,2,3]
 
-FLATTEN([[1],[1],[3]])
-=>
-[1,3]
+#### IF(condition, true_stmt, false_stmt)
+If the condition is true, the true_stmt is returned, if the condition is false, the false_stmt is retunred. 
+```ruby
+IF(EQUALS(1,1),3,4) 
+=> 3 --> EQUALS(1,1) returns 'true', so 3 is returned.
 
+IF(EQUALS(1,2),3,4)
+=> 4 --> EQUALS(1,2) returns 'false', so 4 is returned.
 ```
 
+### Core functions
 
+The Core functions form the core of GQL. With these functions you can extract data from elements of the model. 
+
+#### V(args)
+
+Shortcut for the LOOKUP and MAP function. Also see LOOKUP() and MAP().
+Used to retrieve information from the energy graph.
+
+Example with node
+```ruby
+V(foo) --> LOOKUP(foo)
+=> foo
+```
+
+Example Lookup multiple nodes by their keys
+```ruby
+V(foo,bar) --> LOOKUP(foo,bar)
+=> [<foo>, <bar>]
+```
+
+Example Lookup a node attribute
+```ruby
+V(foo,demand) --> MAP(LOOKUP(foo,demand))
+=> 100 (When demand of node 'foo' is equal to 100)
+```
+
+Example nesting of LOOKUPs
+```ruby
+V(V(foo), V(bar), demand) --> MAP(LOOKUP(foo, LOOKUP(bar)), demand)
+=> 100, 200 
+```
+
+Example pass objects to V()
+```ruby
+V(CARRIER(electricity), cost_per_mj) --> = MAP( LOOKUP(CARRIER(electricity)), cost_per_mj )
+=> 23.3
+```
+
+#### MV(args)
+
+Same functionalities as V, but used for the molecule graph. 
+
+#### Q(key)
+
+QUERY() or Q() returns the result of a gquery with given key.
+
+Example costs
+
+```ruby
+Q(total_costs)
+=> 100
+```
+
+#### FILTER(collection, filter)
+Imposes a filter.
+
+Can be used to impose a filter on node groups based on node attributes, see example.
+
+Example:
+
+```ruby
+FILTER(G(electricity_production),"geothermal_input_conversion > 0.0")
+=> 
+[
+  <#Node energy_power_geothermal>,
+]
+```
+
+#### CHILDREN(*nodes)
+TO-DO
+
+#### PARENTS(*nodes)
+TO-DO
 
 #### QUERY_PRESENT(key)
 Returns the present value of the the gquery, when given a key.
@@ -782,7 +499,7 @@ error
 Returns the present value of the the gquery, when given a key.
 If the argument is a lambda ( -> { ... }), it returns the present value of the query inside the lamba. 
 
-```
+```ruby
 GRAPH(year)
 =>
 2019      2,019
@@ -810,7 +527,7 @@ error
 #### QUERY_DELTA(key)
 
 Returns the delta of the present value and future value of the query. Note: an operation within this query should be noted inside ( -> { ... }). See examples: 
-```
+```ruby
 QUERY_DELTA(graph_year)  
 => 
 2019: 0.0
@@ -826,19 +543,6 @@ QUERY_DELTA(GRAPH(year))
 error
 ```
 
-#### MIXED
-TODO
-
-
-#### GRAPH(keys)
-Returns an attribute of a graph:
-keys - the name of the attribute.
-```
-GRAPH(year)
-=>
-2019      2,019
-2050      2,050
-```
 
 #### ALL
 Returns an Array of all nodes in the energy graph. #Why is this necesary?
@@ -851,7 +555,7 @@ Can also be found via the engine.
 #### GROUP(group)
 
 Returns an Array of all nodes for a given energy group.
-```
+```ruby
 GROUP(apartments)
 =>
 [
@@ -865,7 +569,7 @@ GROUP(apartments)
 ```
 #### MGROUP(group)
 Returns an Array of all nodes for a given molecule group.
-```
+```ruby
 MGROUP(ccu_emitted)
 
 [
@@ -874,16 +578,16 @@ MGROUP(ccu_emitted)
 ```
 
 #### EDGE_GROUP(group)
-Deprecated?
+TO-DO
 
 #### MEDGE_GROUP
-Deprecated?
+TO-DO
 
 #### SECTOR(sector)
 
 Returns an Array of nodes for a given energy sector
 
-```
+```ruby
 ###SECTOR(households)
 =>
 [
@@ -897,7 +601,7 @@ Returns an Array of nodes for a given energy sector
 
 Returns an Array of nodes for a given molecule sector
 
-```
+```ruby
 SECTOR(energy)
 =>
 [
@@ -907,25 +611,11 @@ SECTOR(energy)
 ]
 ```
 
-#### USE(key)
-
-Returns an Array of nodes for given energy use
-
-```
-USE(energetic)
-[
-  #<Node agriculture_burner_crude_oil>,
-  #<Node agriculture_burner_hydrogen>,
-...
-]
-```
-
-
 #### CARRIER(key)
 Returns an Array of carriers for given key(s). Returns carriers belonging to the energy graph.
 #### Could use some more details on why this is useful.
 
-```
+```ruby
 CARRIER(electricity)
 =>
 [
@@ -940,42 +630,15 @@ Returns an Array of carriers for given key(s). Returns carriers belonging to the
 Returns an attribute.
 
 Example:
-```
+```ruby
 AREA(present_number_of_residences) 
 => 7349500.0
 ```
 
-
-#### INSULATION_COST
-TODO; deprecated?
-
-#### WEATHER_PROPERTY
-deprecated?
-
-#### FEVER_DEMAND
-Useful?
-
-#### FEVER_PRODUCTION
-Useful?
-
-#### CURVE_SET_VARIANTS
-
-#### GOAL
-Deprecated?
-
-#### GOAL_IS_SET
-Deprecated?
-#### GOAL_USER_VALUE
-Deprecated?
-
-
-#### ELEMENT_AT
-Deprecated
-
 #### LAST(values)
 Returns the last element of the array.
 
-```
+```ruby
 LAST(V(1,2,3))
 =>
 3
@@ -984,7 +647,7 @@ LAST(V(1,2,3))
 #### FIRST(values)
 Returns the first element of the array.
 Example:
-```
+```ruby
 LAST(V(1,2,3))
 =>
 1
@@ -993,7 +656,7 @@ LAST(V(1,2,3))
 #### EDGE(lft,rgt)
 
 Returns the edge that goes from the first (lft) to the second node (rgt) for the energy graph. 
-```
+```ruby
 EDGE(energy_import_electricity,energy_interconnector_1_imported_electricity
 )
 =>
@@ -1008,14 +671,14 @@ Returns the edge that goes from the  first (lft) to the second node (rgt) for th
 #### EDGES
 
 Retrieves edges based on given node(s) and optional arguments to filter or specify the type of edges.
-```
-EDGES(L(foo))
+```ruby
+EDGES(V(foo))
 =>
 [foo->gas_1, foo->gas_2, loss1->foo, heat1->foo]
 
-EDGES(L(foo), "share?")
-EDGES(L(foo), "flexible?")
-EDGES(L(foo), "flexible? && share >= 1.0")
+EDGES(V(foo), "share?")
+EDGES(V(foo), "flexible?")
+EDGES(V(foo), "flexible? && share >= 1.0")
 =>
 [Edges based on specified constraints]
 
@@ -1023,23 +686,23 @@ EDGES(OUTPUT_SLOTS(foo, heat))
 =>
 [heat->foo]
 
-EDGES(L(foo, bar))
+EDGES(V(foo, bar))
 =>
 [Edges of multiple nodes]
 ```
 
 #### OUTPUT_SLOTS
 Gets the output (to the left) slots of node(s). Can specify a particular type of slot or retrieve all output slots.
-```
+```ruby
 OUTPUT_SLOTS(foo)
 =>
 [(loss)-foo, (heat)-foo]
 
-OUTPUT_SLOTS(L(foo))
+OUTPUT_SLOTS(V(foo))
 =>
 [(loss)-foo, (heat)-foo]
 
-OUTPUT_SLOTS(L(foo, bar))
+OUTPUT_SLOTS(V(foo, bar))
 =>
 [(loss)-foo, (heat)-foo, ...]
 
@@ -1053,7 +716,7 @@ OUTPUT_SLOTS(foo, loss)
 Gets the input (to the right) slots of node(s). Can specify a particular type of slot or retrieve all input slots.
 Examples:
 
-```
+```ruby
 INPUT_SLOTS(foo)
 =>
 [foo-(gas), foo-(oil)]
@@ -1067,14 +730,14 @@ INPUT_SLOTS(foo, gas)
 INPUT_EDGES(value_terms, arguments = nil)
 Retrieves input edges based on given node(s) and optional arguments to filter or specify the type of edges.
 Examples:
-```
-INPUT_EDGES(L(foo))
+```ruby
+INPUT_EDGES(V(foo))
 =>
 [All input edges of node 'foo']
 
-INPUT_EDGES(L(foo), "share?")
-INPUT_EDGES(L(foo), "flexible?")
-INPUT_EDGES(L(foo), "flexible? && share >= 1.0")
+INPUT_EDGES(V(foo), "share?")
+INPUT_EDGES(V(foo), "flexible?")
+INPUT_EDGES(V(foo), "flexible? && share >= 1.0")
 =>
 [Input edges based on specified constraints]
 
@@ -1082,21 +745,21 @@ INPUT_EDGES(INPUT_SLOTS(foo, oil))
 =>
 [foo->oil_1]
 
-INPUT_EDGES(L(foo, bar))
+INPUT_EDGES(V(foo, bar))
 =>
 [Input edges of multiple nodes]
 ```
 
 #### OUTPUT_EDGES
 Retrieves output edges based on given node(s) and optional arguments to filter or specify the type of edges.
-```
-OUTPUT_EDGES(L(foo))
+```ruby
+OUTPUT_EDGES(V(foo))
 =>
 [All output edges of node 'foo']
 
-OUTPUT_EDGES(L(foo), "share?")
-OUTPUT_EDGES(L(foo), "flexible?")
-OUTPUT_EDGES(L(foo), "flexible? && share >= 1.0")
+OUTPUT_EDGES(V(foo), "share?")
+OUTPUT_EDGES(V(foo), "flexible?")
+OUTPUT_EDGES(V(foo), "flexible? && share >= 1.0")
 =>
 [Output edges based on specified constraints]
 
@@ -1104,17 +767,245 @@ OUTPUT_EDGES(OUTPUT_SLOTS(foo, heat))
 =>
 [heat->foo]
 
-OUTPUT_EDGES(L(foo, bar))
+OUTPUT_EDGES(V(foo, bar))
 =>
 [Output edges of multiple nodes]
 ```
 
+### Curves functions
 
+With these functions you can perform operations with curves from the merit or fever modules.
 
-#### EACH
-Runs multiple (update) queries.
+#### CLAMP_CURVE(curve, min, max)
+
+Restricts the values in a curve to be between the minimum and maximum. Raises an error if min > max.
+
 Example:
+```ruby
+CLAMP_CURVE([1,2,3,4],0,2)
+=> [1,2,2,2]
+
+CLAMP_CURVE([1,-2,3,-4],0,2)
+=> [1,0,2,0]
 ```
+
+#### COALESCE_CURVE(curve, default = 0.0, length = 8760)
+
+If the given `curve` is an array of non-zero length, it is returned. If the curve is nil or empty, a new curve of `length` length is created, with each value set to `default`.
+
+Example with 'nil':
+```ruby
+COALESCE_CURVE(nil,3,5)
+=> [3,3,3,3,3]
+
+COALESCE_CURVE(nil)
+=> [0,0,0,...,0]
+Since no values are given for default & length, these are set to 0 & 8760 respectively
+
+```
+
+#### CUMULATIVE_CURVE(curve)
+
+Creates a new curve where each index (n) is the sum of (0..n) in the source curve.
+Example:
+
+```ruby
+CUMULATIVE_CURVE([1, 2,3,4])
+=> [1,3,6,10]
+
+CUMULATIVE_CURVE([1,-2,3,-4])
+=> [1,-1,2,-2]
+```
+
+
+#### INVERT_CURVE(curve)
+
+Inverts a single curve by swapping positive numbers to be negative, and vice-versa.
+Example:
+
+```ruby
+INVERT_CURVE([1, 2,3,4])
+=> [-1,-2,-3,-4]
+
+INVERT_CURVE([1,-2,3,-4])
+=> [-1,2,-3,4]
+```
+
+
+#### SUM_CURVES(*curves)
+Adds the values in multiple curves.
+
+
+Example:
+
+```ruby
+SUM_CURVES([1, 2], [3, 4])
+=> [4, 6]
+
+SUM_CURVES([[1, 2], [3, 4]])
+=> [4, 6]
+```
+
+#### PRODUCT_CURVES(left,right)
+Multiplies two curves elementwise.
+Note that unlike `SUM_CURVES`, `PRODUCT_CURVES` expects exactly two arguments, each one a curve.
+An error will be raised if either parameter is an array of curves, or if the curves don't have matching lengths.
+
+Example:
+```ruby
+PRODUCT_CURVES([1, 2, 3], [4, 5, 6])
+=> [4, 10, 18]
+```
+
+#### DIVIDE_CURVES(left, right)
+Divides two curves elementwise.
+Note that unlike `SUM_CURVES`, `PRODUCT_CURVES` expects exactly two arguments, each one a curve.
+An error will be raised if either parameter is an array of curves, or if the curves don't have matching lengths.
+```ruby
+DIVIDE_CURVES([1, 2, 3], [4, 5, 6])
+=> [0.25, 0.4, 0.5]
+```
+
+#### SMOOTH_CURVE(curve, window_size)
+Creates a smoothed curve using a moving average.
+curve       - An array of numbers.
+window_size - The number of points to average over.
+
+### Helper functions
+
+These functions can support the user in gaining a quick insight in the data. See the examples below for use cases of these functions.
+
+#### SORT_BY(*objects, arguments)
+With SORT_BY nodes can be sorted on one of their attributes.
+The nodes will be sorted ascending to the value of the attribute.
+Ranking of the nodes will start from 0.
+Note that the value of the attribute will not be printed, see TXT_TABLE for this functionality.
+
+Example with the group 'useful_demand'.
+```ruby
+SORT_BY(G(useful_demand),demand)
+=> 
+[
+  #<Node industry_useful_demand_for_chemical_other_hydrogen_non_energetic> 0,
+  #<Node bunkers_useful_demand_ships> 1,
+  ...,
+]
+```
+
+
+#### TXT_TABLE(objects, *argyments)
+With TXT_TABLE 1 or more attributes from a node group can be queried.
+The nodes in the given node group will be sorted alphabetically.
+
+Within the GQL-sandbox users can choose how the view the table in 4 different modes:
+* Table: Shows the table in standard GQL-sandbox format.
+* Text: Shows the table in text-format.
+* CSV: Shows the table in CSV (comma seperated values) format.
+* TSV: Shows the table in TSV (tab seperated values) format.
+
+Note: With 'key' the name of the node is printed.
+
+Example (output in text format, for readibility only the first 2 and last 2 rows of the table are shown):
+```ruby
+TXT_TABLE(G(useful_demand),key,demand)
+=> 
++------------------------------------------------------------------------------+--------------------+
+|                                     key                                      |       demand       |
++------------------------------------------------------------------------------+--------------------+
+| agriculture_useful_demand_electricity                                        | 40964534066.695656 |
+| agriculture_useful_demand_useable_heat                                       | 98697676910.08954  
+|...                                                                           | ...                |
+| transport_useful_demand_trucks                                               | 144749566437.32986 |
+| transport_useful_demand_vans                                                 | 1280922944.4741797 |
++------------------------------------------------------------------------------+--------------------+
+```
+
+This function can be combined with SORT_BY, so that a quick overview of the nodes with the highest attributes can be found.
+
+Example with SORT_BY (output in text format, for readibility only the first 2 and last 2 rows of the table are shown):
+```ruby
+TXT_TABLE(SORT_BY(G(useful_demand),demand),key,demand)
+=> 
++------------------------------------------------------------------------------+--------------------+
+|                                     key                                      |       demand       |
++------------------------------------------------------------------------------+--------------------+
+| industry_useful_demand_for_chemical_other_hydrogen_non_energetic             | 0.0                |
+| bunkers_useful_demand_ships                                                  | 0.0                |
+|...                                                                           | ...                |
+| industry_useful_demand_for_chemical_other_non_energetic                      | 414554538059.73004 |
+| industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic       | 2650973321780.0    |
++------------------------------------------------------------------------------+--------------------+
+```
+#### EACH
+Lets the user run multiple queries.
+Example:
+```ruby
+EACH(
+  SUM(foo, ...),
+  SUM(bar, ...)
+)
+=>
+[Results of SUM queries]
+
+```
+
+### Set functions
+These functions concern operations associated with graph theory.
+
+
+#### INTERSECTION(*keys)
+Returns the elements that are present in both the first and second arrays.
+
+```ruby
+INTERSECTION( V(1,2,3) , V(2,3,4) )
+=> [2, 3]
+```
+
+#### EXCLUDE(*keys)
+Returns an Array of elements of the first array excluding the second array.
+```ruby
+EXCLUDE( V(1,2,3) , V(2,3,4) )
+=> [1]
+```
+
+
+### Fever functions
+
+These functions concern operations associated with the Fever module.
+
+#### FEVER_DEMAND
+TO-DO
+
+#### FEVER_PRODUCTION
+TO-DO
+#### FEVER_PRODUCTION_CURVE_FOR_COUPLE
+TO-DO
+
+#### FEVER_DEMAND_CURVE_FOR_PEOPLE
+TO-DO
+
+#### FEVER_PRODUCTION_CURVE
+TO-DO
+#### FEVER_DEMAND_CURVE
+TO-DO
+
+### Update functions
+These functions concern operations used to update values in the model.
+
+
+#### UPDATE
+Updates attributes or elements based on the specified conditions or inputs, with various strategies (absolute, relative_total, or relative_per_year).
+Can be combined with the UPDATE function.
+
+```ruby
+UPDATE(V(foo), demand, 100)
+=>
+Demand becomes 100
+
+UPDATE(V(foo, bar, baz), demand, 5)
+=>
+Demand of all nodes becomes 5
+
 EACH(
   UPDATE(foo, ...),
   UPDATE(bar, ...)
@@ -1122,25 +1013,12 @@ EACH(
 =>
 [Results of UPDATE queries]
 
-```
-
-#### UPDATE
-Updates attributes or elements based on the specified conditions or inputs, with various strategies (absolute, relative_total, or relative_per_year).
-
-```
-UPDATE(L(foo), demand, 100)
-=>
-Demand becomes 100
-
-UPDATE(L(foo, bar, baz), demand, 5)
-=>
-Demand of all nodes becomes 5
 
 ```
 #### UPDATE_WITH_FACTOR
 Same as UPDATE, but the input value is expected to be a factor that the user supplies.
 Example:
-```
+```ruby
 UPDATE_WITH_FACTOR(V(foo), preset_demand, 1.1)
 =>
 Foo gets a demand of 110.0
@@ -1150,8 +1028,8 @@ Foo gets a demand of 110.0
 #### UPDATE_ABSOLUTE
 Same as UPDATE, but forcefully behaving as the absolute strategy.
 Example:
-```
-UPDATE_ABSOLUTE(L(foo), demand, 500)
+```ruby
+UPDATE_ABSOLUTE(V(foo), demand, 500)
 =>
 Demand of foo becomes 500
 
@@ -1160,7 +1038,7 @@ Demand of foo becomes 500
 #### USER_INPUT
 Retrieves the numeric value of the user input, handling different formats (absolute, percentage, etc.).
 Example:
-```
+```ruby
 USER_INPUT()
 =>
 3.0 (if the user input is "3")
@@ -1169,29 +1047,27 @@ USER_INPUT()
 #### INPUT_VALUE(key)
 Retrieves the value of a specified input.
 Example:
-```
+```ruby
 INPUT_VALUE('agriculture_geothermal_share')
 =>
 0.104
 ```
 
-#### UPDATE_OBJECT()
-Accesses the currently updated object in the context of an UPDATE statement.
-Example:
-```
-UPDATE(L(foo, bar), demand, -> {V(UPDATE_OBJECT(), demand) + USER_INPUT()})
-=>
-[Increments demand of foo and bar based on user input]
+### Constants
 
-```
-
-#### UPDATE_COLLECTION()
-Accesses all objects in the current UPDATE statement.
-Example:
-```
-UPDATE(L(foo, bar, baz), demand, -> {
-  SUM(V(UPDATE_COLLECTION(), demand)) - V(UPDATE_OBJECT(), demand)
-})
-=>
-[Updates demands of foo, bar, baz with the remainder]
+```ruby
+MWH_TO_GJ = 3.6
+MONTHS_PER_YEAR = 12.0
+HOURS_PER_YEAR = 8760.0
+SECS_PER_HOUR = 3600.0
+SECS_PER_YEAR = SECS_PER_HOUR * HOURS_PER_YEAR
+KG_PER_TONNE = 1000
+LITER_PER_BARREL = 159
+MJ_TO_MHW = 3600
+MJ_PER_KWH = 3.6
+MJ_PER_MWH = 3600
+BILLIONS = 10.0**9
+MJ_TO_PJ = BILLIONS
+MILLIONS = 10.0**6
+THOUSANDS = 1000.0
 ```

--- a/sidebars.js
+++ b/sidebars.js
@@ -148,6 +148,7 @@ module.exports = {
         "contrib/inputs",
         "contrib/molecules",
         "contrib/waste-outputs",
+        "contrib/gql"
       ],
     },
     {


### PR DESCRIPTION
This PR adds documentation for GQL. It partly retrieves the information from [this outdated page](https://github.com/quintel/documentation/blob/e4ad8076be511b5b3953909e268016c9ecd41438/general/GQL.md) and partly directly from the[ ETEngine functions](https://github.com/quintel/etengine/tree/master/app/models/gql/runtime/functions). Some documentation is new.

There are four critical points for review:

- [ ] Are the guidelines under "Writing gqueries" clear, exhaustive etc. or does more information have to be added?
- [ ] Is the guideline for nomenclature of gqueries useful, clear etc.?
- [ ] Are GQL functions missing or should some be removed?
- [ ] Is the categorization of GQL functions clear or should be restructured/renamed (core functions, math functions etc.)?

There are still some GQL functions that need documentation and now have "TO-DO". What was your intention with these functions @kaskranenburgQ?
