### PR TITLE
Added roles and rights section in version history documentation

### DIFF
--- a/docs/main/managing-scenarios/scenario-version-history.md
+++ b/docs/main/managing-scenarios/scenario-version-history.md
@@ -8,3 +8,17 @@ The following actions can be taken in the version history overview:
 - **Open a specific scenario version**: If you want to open a specific scenario, click on the name of the person indicated to be the last one that made changes to the scenario (the text turns blue when you hover on it).
 - **Edit the description of a scenario version**: Click on the pencil incon on the right to make changes to the description of a specific version. 
 - **Restore an older scenario version**: You can restore your scenario to an older version. This means that applied changes after this scenario version will be lost. This action is irreversible. A warning pop-up will appear as an extra precaution for this action. 
+
+### Roles and rights
+
+Depending on the user's role in a particular scenario (<i>Viewer</i>, <i>Collaborator</i> or <i>Owner</i>, also see [manage acces](scenario-access-management.md#roles) for more information on these roles), it is possible to perform the above-mentioned actions. The following table shows which actions concerning scenario version history can be performed per role:
+
+| Role | Viewer | Collaborator | Owner |
+| ---- | ---- | ---- | ---- |
+| Open a specific scenario version |  | ✓  | ✓ |  
+| Edit description of a scenario version |  | ✓ | ✓  |  
+| Restore an older scenario version |  |  | ✓ | 
+
+- **Viewer**: A viewer cannot see the version history of a scenario. A viewer can only open the most recent version of a scenario. 
+- **Collaborator**: Can open older scenario versions and edit the description of scenario versions.
+- **Owner**: In addition to the rights of a collaborator, the owner can restore older scenario versions. 


### PR DESCRIPTION
A table with the rights per user role is added to the version history documentation. 