### PR TITLE
Power shortage dashboard item

### DIFF
--- a/docs/main/dashboard.md
+++ b/docs/main/dashboard.md
@@ -81,8 +81,8 @@ The loss of load dashboard item shows the number of hours in which the capacity 
 
 _Checkout: the ['Loss of load'](loss-of-load-expectation) infopage for more information._
 
-### Number of blackout hours
-The total number of blackout hours can be determined using the hourly electricity production calculations compared to the hourly electricity demand. If regional electricity production and the maximum amount of electricity import is not enough to satisfy the demand, a blackout will occur. The graph shows the hourly electricity production compared to the hourly electricity demand.
+### Power shortage
+This dashboard item shows the number of hours per year during which a power shortage occurs. Power shortages occur when electricity supply is insufficient to meet electricity demand and when it is not possible to fill this gap with electricity import or flexible technologies such as electricity storage. The ETM calculates power shortages on hourly basis. The table shows information about the volume, peak capacity and duration of power shortages in a scenario. 
 
 ### Number of hours with excess electricity
 As a result of large numbers of wind turbines and solar panels installed, the supply of electricity can be larger than the demand. The number of hours with excess electricity displays this event. If you include flexibility options in your scenario, the number of excess events decreases.

--- a/docs/main/dashboard.md
+++ b/docs/main/dashboard.md
@@ -82,7 +82,7 @@ The loss of load dashboard item shows the number of hours in which the capacity 
 _Checkout: the ['Loss of load'](loss-of-load-expectation) infopage for more information._
 
 ### Power shortage
-This dashboard item shows the number of hours per year during which a power shortage occurs. Power shortages occur when electricity supply is insufficient to meet electricity demand and when it is not possible to fill this gap with electricity import or flexible technologies such as electricity storage. The ETM calculates power shortages on hourly basis. The table shows information about the volume, peak capacity and duration of power shortages in a scenario. 
+This dashboard item shows the number of hours per year during which a power shortage occurs. Power shortages occur when electricity supply is insufficient to meet electricity demand and when it is not possible to fill this gap with electricity import or flexible technologies such as electricity storage. The ETM calculates power shortages on an hourly basis. The table shows information about the volume, peak capacity and duration of power shortages in a scenario. 
 
 ### Number of hours with excess electricity
 As a result of large numbers of wind turbines and solar panels installed, the supply of electricity can be larger than the demand. The number of hours with excess electricity displays this event. If you include flexibility options in your scenario, the number of excess events decreases.

--- a/docs/main/scenario-tools/retrieving-data.md
+++ b/docs/main/scenario-tools/retrieving-data.md
@@ -37,7 +37,7 @@ The `queries.csv` file contains a list of queries that will be collected for eac
 |---|
 | dashboard_co2_emissions_versus_start_year |
 | dashboard_total_costs |
-| dashboard_blackout_hours |
+| dashboard_power_shortage_hours |
 
 
 ### data_downloads.csv


### PR DESCRIPTION
This PR rebrands the blackout hours dashboard item to "Power shortage"
It adds new documentation for this dashboard. 

Goes together with:
https://github.com/quintel/etengine/pull/1564
https://github.com/quintel/merit/pull/157
https://github.com/quintel/etsource/pull/3262
https://github.com/quintel/etmodel/pull/4487
