### PR TITLE
Add note on environments for token usage

### DIFF
--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -5,6 +5,7 @@ title: Authentication
 import endpointData from '@site/data/api/tokens';
 import ApiEndpoint from '@site/src/components/ApiEndpoint';
 import UpcomingFeature from '@site/src/components/UpcomingFeature';
+import { StagingBadge, StableBadge, ProductionBadge } from '@site/src/components/EnvBadge';
 
 <UpcomingFeature release="2023.01" />
 
@@ -40,6 +41,11 @@ Host: engine.energytransitionmodel.com
 Accept: application/json
 Authorization: Bearer etm_xcNxTaX8KLr5LkGs93sRWnGfhyAUDPWPqKVGe1RL73GJUnfQ
 ```
+
+#### Tokens are environment-specific
+
+- <ProductionBadge /> tokens can be used in both the production and stable environments.
+- <StagingBadge /> tokens are valid only in the staging environment.
 
 ## Using the API without authentication
 


### PR DESCRIPTION
Minor change to authentication documentation to indicate your pro API token can be used to access the stable version API endpoint.

Closes #231 