### PR TITLE
Link to the ETM by clicking Button

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -23,7 +23,7 @@ module.exports = {
       items: [
         {
           href: "https://energytransitionmodel.com/",
-          label: "To the ETM",
+          label: "To the ETM →",
           position: "right",
           className: "navbar__link--etm-button",
         },

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -154,6 +154,10 @@ header h1 {
   text-decoration: none;
 }
 
+.navbar__link--etm-button svg {
+  display: none !important;
+}
+
 .col + .col {
   padding-left: 0;
 }


### PR DESCRIPTION
## Description
We don't really have a consistent ETM logo, but I made the 'title' in the top left where it says 'Energy Transition Model' link to the front end of ETModel.

I think there's a lot to be considered with the visual design of this, hence tagging @noracato and @kndehaan for your thoughts on this approach.

Closes #269 

EDIT: Updated to be a button in the top right: "To the ETM"
