### PR TITLE
Update Demand docs to include Energy sector

### DIFF
--- a/docs/main/demand.md
+++ b/docs/main/demand.md
@@ -16,29 +16,29 @@ Demand consists of a number of domestic demand sectors and export:
 For each of the demand sectors shown in the Demand tab in the ETM, a percentage is displayed. This indicates primary energy used to supply the energy use of that particular sector, as a share in the total primary energy use for domestic demand.
 
 ## Households
-In the Households section the demand for energy in households is specified. The demand growth of energy and the technology mix that uses this energy can be specified. The focus is on technologies used for heating, insulation, cooking, cooling, lighting and appliances. Additionally, you can specify the number and typical heat demand of residences per type and construction period.
+In the [Households](https://energytransitionmodel.com/scenario/demand/households/overview) section the demand for energy in households is specified. The demand growth of energy and the technology mix that uses this energy can be specified. The focus is on technologies used for heating, insulation, cooking, cooling, lighting and appliances. Additionally, you can specify the number and typical heat demand of residences per type and construction period.
 
 ## Buildings
-The Buildings section contains all non-residential buildings in the services sector. This includes office buildings, schools and hospitals. Similar to the Households section, the focus lies on heating, cooling, ventilation, insulation, lighting and roof top solar PV.
+The [Buildings](https://energytransitionmodel.com/scenario/demand/buildings/overview) section contains all non-residential buildings in the services sector. This includes office buildings, schools and hospitals. Similar to the Households section, the focus lies on heating, cooling, ventilation, insulation, lighting and roof top solar PV.
 
 ## Transport
-The Transport section contains four sub-sections: Passenger transport, Freight transport, International transport and Transport fuels. In the specific sub-sections, the type of technology and the transport fuels that are used can be changed. Emissions from international transport are by default not accounted for; this assumption can be changed in the international transport sub-section.
+The [Transport](https://energytransitionmodel.com/scenario/demand/transport/overview) section contains four sub-sections: Passenger transport, Freight transport, International transport and Transport fuels. In the specific sub-sections, the type of technology and the transport fuels that are used can be changed. Emissions from international transport are by default not accounted for; this assumption can be changed in the international transport sub-section.
 
 ## Industry
-The Industry section contains the economic sector industry as well as the part of the energy sector own use. The industry sector is divided into twelve sub-sectors. In the ETM these are aggregated to:
+The [Industry](https://energytransitionmodel.com/scenario/demand/industry/energy-demand-in-the-industry) section contains the economic sector industry as well as the part of the energy sector own use. The industry sector is divided into twelve sub-sectors. In the ETM these are aggregated to:
 * Metal industry (steel, aluminum and other metals)
 * Chemical industry (refineries, fertilizers, chemicals)
 * Other industry (ICT, food, paper, other non-specified)
 
 ## Agriculture
-In the Agriculture section you can adjust the growth or decline of agricultural heat or electricity demand. Furthermore, you can adjust the technologies used for heating in the agricultural section.
+In the [Agriculture](https://energytransitionmodel.com/scenario/demand/agriculture/development-of-demand) section you can adjust the growth or decline of agricultural heat or electricity demand. Furthermore, you can adjust the technologies used for heating in the agricultural section.
 
 ## Other
-The Other sector contains all energy use not represented in the previous sectors. It differs slightly per region and is usually small. It for example includes energy use by the military.
+The [Other](https://energytransitionmodel.com/scenario/demand/other/development-of-demand) sector contains all energy use not represented in the previous sectors. It differs slightly per region and is usually small. It for example includes energy use by the military.
 
 ## Energy
-The demand of the Energy sector cannot be set directly, which is why it does not have its own Demand tab. It consists of the own use of electricity for power plants and CHPs, the energy use for Direct Air Capture (DAC) and for storage of CO<sub>2</sub>. Note that all other energy sector own use is allocated to the industry sector.
+The demand of the Energy sector cannot be set directly, which is why it does not have its own section in the Demand tab. It consists of the own use of electricity for power plants and CHPs, the energy use for Direct Air Capture (DAC) and for storage of CO<sub>2</sub>. Note that all other energy sector own use is allocated to the industry sector.
 
 ## Export
-The Export section contains all energy export.
+The [Export](https://energytransitionmodel.com/scenario/demand/export_energy/introduction) section contains all energy export.
 In this section, the (inflexible) export volumes pertaining several energy carriers can be set. Information regarding the import, export and transit flows of energy carriers can be found here as well. Transit flows represent the quantity of energy per carrier that is imported and exported by the country while not being used by said country. This can cause extra pressure on the country's infrastructure for energy carrier transport or storage. Gaining insights in import, export, and transit flows of energy carriers is useful for energy system and infrastructure planning.


### PR DESCRIPTION
This closes https://github.com/quintel/documentation/issues/150 by including some documentation about the Energy sector to the docs for Demand.

Note: the Demand docs can be more structurally revise to clearly describe the mapping from the energy balance to the ETM, but that's for further improvement.