### PR TITLE
Update upcoming release date

### DIFF
--- a/data/releases.js
+++ b/data/releases.js
@@ -76,7 +76,7 @@ const releases = {
 // Main releases timeline data
 export const mainReleases = [
   {
-    date: "Jan 8, 2025",
+    date: "Feb 5, 2026",
     title: "Next Release",
     file: "upcoming.md",
     version: "upcoming",


### PR DESCRIPTION
## Description

Due to the cancelled deploy, the upcoming changes date is now changed to 5 February 2026. 

Alternatively, from now on we could only use the tags instead, so in this case refer to 2026.01 instead of the exact date. @mabijkerk what do you think? It might however also be convenient for users to see exactly when changes are expected (for upcoming). I'm not sure if the date of deploys in the past is very useful though...

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [x] Documentation

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review

## Related Issues

Closes #
