### PR TITLE
Update reference to dispatchable gas power plant

### DIFF
--- a/docs/contrib/molecules.md
+++ b/docs/contrib/molecules.md
@@ -87,7 +87,7 @@ Energy nodes using `from_molecules` should have an initial demand set by ETSourc
 Every molecule node that receives a demand from an energy node must define a `source` attribute. This should match the key of an energy node where a demand is already known.
 
 ```
-- from_energy.source = energy_power_combined_cycle_network_gas
+- from_energy.source = energy_power_combined_cycle_network_gas_dispatchable
 ```
 
 ### The `direction` attribute
@@ -130,7 +130,7 @@ When used in combination with a `direction`, `conversion` allows each input or o
 For every 1MJ of energy (node demand) on the gas power plant, 0.5kg of molecules will be set on the molecule graph:
 
 ```
-- from_energy.source = energy_power_combined_cycle_network_gas
+- from_energy.source = energy_power_combined_cycle_network_gas_dispatchable
 - from_energy.conversion = 0.5
 ```
 

--- a/docs/contrib/recursive-methods.md
+++ b/docs/contrib/recursive-methods.md
@@ -73,11 +73,11 @@ V(agriculture_final_demand_electricity, primary_co2_emission_of_bio_carriers) = 
 
 #### Example:
 ```
-V(energy_power_combined_cycle_network_gas, weighted_carrier_cost_per_mj) = 0.0075 [EUR/MJ]
+V(energy_power_combined_cycle_network_gas_dispatchable, weighted_carrier_cost_per_mj) = 0.0075 [EUR/MJ]
 
-V(energy_power_combined_cycle_network_gas, weighted_carrier_co2_per_mj) = 0.025 [kg CO₂/MJ]
+V(energy_power_combined_cycle_network_gas_dispatchable, weighted_carrier_co2_per_mj) = 0.025 [kg CO₂/MJ]
 
-V(energy_power_combined_cycle_network_gas, weighted_carrier_potential_co2_per_mj) = 0.030 [kg CO₂/MJ]
+V(energy_power_combined_cycle_network_gas_dispatchable, weighted_carrier_potential_co2_per_mj) = 0.030 [kg CO₂/MJ]
 ```
 
 ### Sustainable


### PR DESCRIPTION
#### Context

This PR updates the reference to a gas power plant, which has been renamed with "_dispatchable". 

#### Related

Goes with pull requests:
- ETModel: https://github.com/quintel/etmodel/pull/4698
- ETSource: https://github.com/quintel/etsource/pull/3433
- ETEngine: https://github.com/quintel/etengine/pull/1734
- Documentation: https://github.com/quintel/documentation/pull/306
- Mechanical Turk: https://github.com/quintel/mechanical_turk/pull/217
- Multi-year-charts: https://github.com/quintel/multi-year-charts/pull/119
- ETDataset: https://github.com/quintel/etdataset/pull/1083

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review
