### PR TITLE
Improve query example in writing queries docs

### DIFF
--- a/docs/contrib/authoring-gqueries.md
+++ b/docs/contrib/authoring-gqueries.md
@@ -16,21 +16,23 @@ Gqueries are in fact stored [GQL](gql.md) (Graph Query Language) procedures that
 
 Example for `final_demand_energetic_industry_steel_wood_pellets`:
 ```
-# Energetic final demand of the 'coal' carrier group in industry steel sector.
+# Energetic final demand of the 'coal' carrier group in households appliances
 
 - query =
-    SUM(
-      V(
-        FILTER(
+    DIVIDE(
+      SUM(
+        V(
           FILTER(
-            INTERSECTION(EG(final_demand),EG(appliances_households)
+            FILTER(
+              INTERSECTION(EG(final_demand),EG(appliances_households)),
+              "coal? || coal_gas? || cokes? || lignite?"
             ),
-            "coal? || coal_gas? || cokes? || lignite?"
+            "energetic?"
           ),
-          "energetic?"
-        ),
-        value
-      )
+          value
+        )
+      ),
+      BILLIONS
     )
 - unit = PJ
 ```


### PR DESCRIPTION
#### Context
The example query in the [writing queries](https://docs.energytransitionmodel.com/contrib/authoring-gqueries/) documentation was incorrect. This has been improved. 
