### PR TITLE
Update labels, links and descriptions renaming power-to-gas to electrolysis

### DIFF
--- a/docs/main/cost-dashboard.md
+++ b/docs/main/cost-dashboard.md
@@ -29,7 +29,7 @@ This page explains the six main groups that comprise the total annual costs disp
 
 4. **Storage and conversion:** Installation-related costs (CAPEX + OPEX). All G2P is associated with means of 'Energy production'. Subgroups:
   -  Power-to-power (p2p)
-  -  Power-to-gas (p2g), onshore and offshore
+  -  Electrolysis from grid on land
   -  Power-to-heat (p2h)
   -  Storage (of hydrogen and heat)
 

--- a/docs/main/cost-dashboard.md
+++ b/docs/main/cost-dashboard.md
@@ -27,9 +27,9 @@ This page explains the six main groups that comprise the total annual costs disp
   -  Hydrogen network
   -  Electricity network
 
-4. **Storage and conversion:** Installation-related costs (CAPEX + OPEX). This group is associated with means of 'Energy production'. Subgroups:
+4. **Storage and conversion:** Installation-related costs (CAPEX + OPEX). Subgroups:
   -  Power-to-power (p2p)
-  -  Electrolysis: electrolysis from grid on land and wind offshore with hybrid connection
+  -  Electrolysis (from grid on land and wind offshore with hybrid connection)
   -  Power-to-heat (p2h)
   -  Storage (of hydrogen and heat)
 

--- a/docs/main/cost-dashboard.md
+++ b/docs/main/cost-dashboard.md
@@ -27,9 +27,9 @@ This page explains the six main groups that comprise the total annual costs disp
   -  Hydrogen network
   -  Electricity network
 
-4. **Storage and conversion:** Installation-related costs (CAPEX + OPEX). All G2P is associated with means of 'Energy production'. Subgroups:
+4. **Storage and conversion:** Installation-related costs (CAPEX + OPEX). This group is associated with means of 'Energy production'. Subgroups:
   -  Power-to-power (p2p)
-  -  Electrolysis from grid on land
+  -  Electrolysis: electrolysis from grid on land and wind offshore with hybrid connection
   -  Power-to-heat (p2h)
   -  Storage (of hydrogen and heat)
 

--- a/docs/main/cost-methods.md
+++ b/docs/main/cost-methods.md
@@ -5,50 +5,50 @@ title: Cost methods
 The ETM defines six main cost groups, consisting of various subgroups. These subgroups are the sum of individual technologies and some additional modules. A detailed breakdown of all groups, subgroups and modules and can be found in the [data export](https://energytransitionmodel.com/scenario/data/data_export/specifications-annual-costs). A detailed overview of the scope per subgroup can be found in the [Overview of costs per sector](cost-overview-per-sector.md).
 
 ## Main cost groups
-The yearly costs of a scenario in the ETM is built up from all technologies, carriers, and CO<sub>2</sub> costs in a scenario. **Important:** Group 1-4 consists of the CAPEX and OPEX and exclude fuels and CCUS costs. Group 5 includes all the fuel costs and group 6 all the CCUS and CO<sub>2</sub> costs. 
+The yearly costs of a scenario in the ETM is built up from all technologies, carriers, and CO<sub>2</sub> costs in a scenario. **Important:** Group 1-4 consists of the CAPEX and OPEX and exclude fuels and CCUS costs. Group 5 includes all the fuel costs and group 6 all the CCUS and CO<sub>2</sub> costs.
 
 1. **Buildings and installations:** Building and installation-related costs (CAPEX + OPEX) of sectors. Subgroups:
-  -  Households  
-  -  Buildings  
-  -  Transport 
-  -  Industry 
-  -  Agriculture 
+  -  Households
+  -  Buildings
+  -  Transport
+  -  Industry
+  -  Agriculture
 
-2. **Energy Production:** Installation-related costs (CAPEX + OPEX) of the energy production sector. Subgroups: 
+2. **Energy Production:** Installation-related costs (CAPEX + OPEX) of the energy production sector. Subgroups:
   -  Power plants
   -  CHP plants (including the industrial steam network)
-  -  Heat plants 
-  -  Dedicated hydrogen production 
+  -  Heat plants
+  -  Dedicated hydrogen production
   -  Biomass treatment
   -  Other intallations (synthetic kerosine, regasification of lng, and energy compressors for network gas)
 
 3. **Infrastructure**: CAPEX + OPEX of the energy infrastructure. Subgroups:
-  -  Natural gas (includes gas network for natural gas and green gas and import infrastructure costs of LNG) 
+  -  Natural gas (includes gas network for natural gas and green gas and import infrastructure costs of LNG)
   -  Heat (network costs)
   -  Hydrogen carriers (includes hydrogen network and import infrastructure costs of liquid hydrogen and LOHC)
   -  Electricity (network costs)
   -  Ammonia (import infrastructure costs of ammonia)
   -  Oil (import infrastructure costs of diesel)
-   
+
 4. **Storage and conversion:** Installation-related costs (CAPEX + OPEX). All G2P is associated with means of 'Energy production'. Subgroups:
   -  Power-to-power (p2p)
-  -  Power-to-gas (p2g) 
+  -  Electrolysis from grid on land
   -  Power-to-heat (p2h)
-  -  Storage (of hydrogen and heat) 
+  -  Storage (of hydrogen and heat)
 
-5. **Energy carriers and import:** All net primary demand of energy carriers.   
+5. **Energy carriers and import:** All net primary demand of energy carriers.
 
-  <i>Cost of carrier = (extraction + import - export) * price of carrier</i>  
+  <i>Cost of carrier = (extraction + import - export) * price of carrier</i>
 
-  For export the ETM charges the costs of the primary carrier that is needed for that export. The export of electricity and transit of oil is cost neutral and independent of the market price. A country does not "earn" money from processing oil. And for electricity the ETM deducts the costs of the primary carriers needed to produce that electricity.  
-  
+  For export the ETM charges the costs of the primary carrier that is needed for that export. The export of electricity and transit of oil is cost neutral and independent of the market price. A country does not "earn" money from processing oil. And for electricity the ETM deducts the costs of the primary carriers needed to produce that electricity.
+
 6. **Carbon capture, utilisation and storage (CCUS):** CAPEX + OPEX of all CCUS technologies, including CO<sub>2</sub> costs.
 
-## CAPEX and OPEX 
+## CAPEX and OPEX
 All costs of groups 1-4 consists of two variables: CAPEX or `capital_expenditures_excluding_ccs` and OPEX or `operating_expenses_excluding_ccs`. Group 6 is similar, but contains all CAPEX and OPEX of the CCUS technologies.
 
 ### **CAPEX**
-Capital expenditures are major investments that are designed to be used for many years. The yearly costs for these investments are based on the total investment over lifetime, WACC and plant lifetime. CCUS and fuel costs are not in the CAPEX and OPEX of group 1-4. 
+Capital expenditures are major investments that are designed to be used for many years. The yearly costs for these investments are based on the total investment over lifetime, WACC and plant lifetime. CCUS and fuel costs are not in the CAPEX and OPEX of group 1-4.
 
 ![](/img/docs/costs_equation_capex.png)
 
@@ -61,7 +61,7 @@ Additional definitions:
 
 ### **OPEX**
 Operating expenses include Operation and Maintenance (O&M) costs, without CCS. O&M costs can have both a variable and a fixed part.
- 
+
 * Variable O&M costs are costs that depend on the number of full load hours of the plant, for additional cleaning and service costs. Note that this excludes [fuel costs](cost-methods.md#fuel-costs), since these are allocated to an individual category.
 * The fixed part are the costs that are made yearly, independent of whether the plant is used or not. Fixed O&M Costs are specified per year and found directly from research. This means that Fixed O&M Costs have no calculations associated with them.
 

--- a/docs/main/cost-methods.md
+++ b/docs/main/cost-methods.md
@@ -32,7 +32,7 @@ The yearly costs of a scenario in the ETM is built up from all technologies, car
 
 4. **Storage and conversion:** Installation-related costs (CAPEX + OPEX). All G2P is associated with means of 'Energy production'. Subgroups:
   -  Power-to-power (p2p)
-  -  Electrolysis from grid on land
+  -  Electrolysis: electrolysis from grid on land and wind offshore with hybrid connection
   -  Power-to-heat (p2h)
   -  Storage (of hydrogen and heat)
 

--- a/docs/main/cost-methods.md
+++ b/docs/main/cost-methods.md
@@ -30,9 +30,9 @@ The yearly costs of a scenario in the ETM is built up from all technologies, car
   -  Ammonia (import infrastructure costs of ammonia)
   -  Oil (import infrastructure costs of diesel)
 
-4. **Storage and conversion:** Installation-related costs (CAPEX + OPEX). All G2P is associated with means of 'Energy production'. Subgroups:
+4. **Storage and conversion:** Installation-related costs (CAPEX + OPEX). Subgroups:
   -  Power-to-power (p2p)
-  -  Electrolysis: electrolysis from grid on land and wind offshore with hybrid connection
+  -  Electrolysis (from grid on land and wind offshore with hybrid connection)
   -  Power-to-heat (p2h)
   -  Storage (of hydrogen and heat)
 

--- a/docs/main/cost-overview-per-sector.md
+++ b/docs/main/cost-overview-per-sector.md
@@ -47,7 +47,7 @@ Below you can find an overview of the different cost components that are taken i
 |  ***Subject***   | ***Cost components***  |
 |---|---|
 | Power-to-power (p2p) | CAPEX and OPEX of houshold batteries, EV batteries, grid batteries, OPAC and pumped storage
-| Power-to-gas (p2g) | CAPEX and OPEX of onshore and offshore electrolysers
+| Electrolysis from grid on land | CAPEX and OPEX of electrolysers connected to the electricity grid
 | Power-to-heat (p2h) | CAPEX and OPEX of industrial p2h boilers
 | Storage | CAPEX and OPEX of hydrogen and heat
 

--- a/docs/main/cost-overview-per-sector.md
+++ b/docs/main/cost-overview-per-sector.md
@@ -47,7 +47,7 @@ Below you can find an overview of the different cost components that are taken i
 |  ***Subject***   | ***Cost components***  |
 |---|---|
 | Power-to-power (p2p) | CAPEX and OPEX of houshold batteries, EV batteries, grid batteries, OPAC and pumped storage
-| Electrolysis from grid on land | CAPEX and OPEX of electrolysers connected to the electricity grid
+| Electrolysis | CAPEX and OPEX of electrolysers connected to the electricity grid and of offshore wind with hybrid connection
 | Power-to-heat (p2h) | CAPEX and OPEX of industrial p2h boilers
 | Storage | CAPEX and OPEX of hydrogen and heat
 

--- a/docs/main/electricity-conversion.md
+++ b/docs/main/electricity-conversion.md
@@ -24,11 +24,11 @@ See [Merit order](merit-order.md) for more information on the clearing of the de
 
 ## Description of technologies
 
-### Power-to-gas
+### Electrolysis from grid on land
 
-Electricity can be used to produce hydrogen through the electrolysis of water. The sustainability of hydrogen from power-to-gas therefore depends on the carbon intensity of the electricity used to produce. In the ETM, the hydrogen produced by power-to-gas will be supplied to the central hydrogen network.
+Electricity can be used to produce hydrogen through the electrolysis of water. The sustainability of hydrogen from electrolysis therefore depends on the carbon intensity of the electricity used to produce. In the ETM, the hydrogen produced by electrolysis will be supplied to the central hydrogen network.
 
-You can determine the installed capacity of onshore power-to-gas plants and their willingness to pay in the [Conversion to hydrogen](https://energytransitionmodel.com/scenario/flexibility/flexibility_conversion/conversion-to-hydrogen) section. Additionally, it is possible to set installed capacity for an offshore electrolyser as part of a hybrid offshore wind hub. Capacity can be installed in the [Flexibility](https://energytransitionmodel.com/scenario/flexibility/flexibility_net_load/hybrid-offshore-wind-components) section. See [Hybrid offshore wind](hybrid-offshore-wind) for more information.
+You can determine the installed capacity of onshore electrolysis and their willingness to pay in the [Conversion to hydrogen](https://energytransitionmodel.com/scenario/flexibility/flexibility_conversion/conversion-to-hydrogen) section. Additionally, it is possible to set installed capacity for an offshore electrolyser as part of a hybrid offshore wind hub. Capacity can be installed in the [Flexibility](https://energytransitionmodel.com/scenario/flexibility/flexibility_net_load/hybrid-offshore-wind-components) section. See [Hybrid offshore wind](hybrid-offshore-wind) for more information.
 
 :::info Hydrogen
 See [Hydrogen](hydrogen.md) for more information about the central hydrogen network; what other types of supply are available, where to set hydrogen demand and how the central hydrogen network is balanced.

--- a/docs/main/electricity-conversion.md
+++ b/docs/main/electricity-conversion.md
@@ -28,7 +28,7 @@ See [Merit order](merit-order.md) for more information on the clearing of the de
 
 Electricity can be used to produce hydrogen through the electrolysis of water. The sustainability of hydrogen from electrolysis therefore depends on the carbon intensity of the electricity used to produce. In the ETM, the hydrogen produced by electrolysis will be supplied to the central hydrogen network.
 
-You can determine the installed capacity of onshore electrolysis and their willingness to pay in the [Conversion to hydrogen](https://energytransitionmodel.com/scenario/flexibility/flexibility_conversion/conversion-to-hydrogen) section. Additionally, it is possible to set installed capacity for an offshore electrolyser as part of a hybrid offshore wind hub. Capacity can be installed in the [Flexibility](https://energytransitionmodel.com/scenario/flexibility/flexibility_net_load/hybrid-offshore-wind-components) section. See [Hybrid offshore wind](hybrid-offshore-wind) for more information.
+You can determine the installed capacity of electrolysis from grid on land and its willingness to pay in the [Flexibility](https://energytransitionmodel.com/scenario/flexibility/flexibility_conversion/conversion-to-hydrogen) section. Additionally, it is possible to set installed capacity for an offshore electrolyser as part of a hybrid offshore wind hub in the [Renewable electricity](https://energytransitionmodel.com/scenario/supply/electricity_renewable/wind-turbines) section. See [Hybrid offshore wind](hybrid-offshore-wind) for more information.
 
 :::info Hydrogen
 See [Hydrogen](hydrogen.md) for more information about the central hydrogen network; what other types of supply are available, where to set hydrogen demand and how the central hydrogen network is balanced.

--- a/docs/main/flexibility.md
+++ b/docs/main/flexibility.md
@@ -11,7 +11,7 @@ Some forms of flexibility are more suited to process large (fluctuations in) vol
 
 _Suitable for large (fluctuations in) volume_
 * Imports/exports of gas/hydrogen
-* Power-to-gas: hydrogen production from electricity
+* Electrolysis: hydrogen production from electricity
 * Storage of gas/hydrogen
 * Seasonal storage of heat
 
@@ -103,7 +103,7 @@ See the [Supply → Hydrogen](https://pro.energytransitionmodel.com/scenario/sup
 * Inflexible:
   * Must-run / volatile: dedicated offshore wind turbine or solar PV plant for H2, steam methane reforming, autothermal reforming, ammonia reforming and biomass gasification
   * Baseload import of hydrogen (flat curve; constant import of hydrogen)
-  * Hydrogen produced by power-to-gas
+  * Hydrogen produced by electrolysis
 * Flexible:
   * Storage production: salt caverns or depleted gas fields
   * Steam methane reforming, autothermal reforming and ammonia reforming

--- a/docs/main/hydrogen.md
+++ b/docs/main/hydrogen.md
@@ -22,10 +22,10 @@ Must-run and volatile sources include all hydrogen sources that supply hydrogen 
 * Autothermal reforming (ATR) with or without CCS
 * Ammonia reforming
 * Biomass gasification with or without CCS
-* Dedicated H<sub>2</sub> production by offshore wind turbines
-* Dedicated H<sub>2</sub> production by solar PV plants
+* Electrolysis from offshore wind (dedicated)
+* Electrolysis from solar on land (dedicated)
 * Price-sensitive H<sub>2</sub> production with electrolysis (capacity can be installed in the [Flexibility](https://energytransitionmodel.com/scenario/flexibility/flexibility_conversion/conversion-to-hydrogen) section)
-* Price-sensitive offshore H<sub>2</sub> production with electrolysis (capacity can be installed in the [Flexibility](https://energytransitionmodel.com/scenario/flexibility/flexibility_net_load/hybrid-offshore-wind-components) section)
+* Price-sensitive offshore wind with hybrid connection for H<sub>2</sub> production (capacity can be installed in the [Renewable electricity](https://energytransitionmodel.com/scenario/supply/electricity_renewable/wind-turbines) section)
 * LH2 regasification
 * LOHC reforming
 * Baseload import

--- a/docs/main/hydrogen.md
+++ b/docs/main/hydrogen.md
@@ -2,7 +2,7 @@
 title: Hydrogen
 ---
 
-There is a growing interest in using hydrogen as energy carrier, for instance for heat production, electricity production, transport fuel or as a feedstock for the chemical industry. Hydrogen could be a solution to bridge the growing imbalance between energy demand and supply due to the increased volatile production of solar and wind electricity. 
+There is a growing interest in using hydrogen as energy carrier, for instance for heat production, electricity production, transport fuel or as a feedstock for the chemical industry. Hydrogen could be a solution to bridge the growing imbalance between energy demand and supply due to the increased volatile production of solar and wind electricity.
 
 :::caution Hydrogen carriers
 There are multiple hydrogen carriers: gaseous hydrogen, liquid hydrogen (LH2) and liquid organic hydrogen carriers (LOHC). Note that when referring to hydrogen, unless stated otherwise, it is implied that gaseous hydrogen is meant.
@@ -12,7 +12,7 @@ With the ETM you can explore the role of hydrogen in the future energy system, u
 
 ## Hydrogen production
 
-Hydrogen sources are composed of inflexible producers (must-run or volatile producers) and flexible producers (dispatchable producers). 
+Hydrogen sources are composed of inflexible producers (must-run or volatile producers) and flexible producers (dispatchable producers).
 
 ### Must-run and volatile
 
@@ -32,21 +32,21 @@ Must-run and volatile sources include all hydrogen sources that supply hydrogen 
 
 SMR and biomass gasification are mature technologies that are used all over the world. In contrast, ammonia reforming and ATR are more novel technologies that still require development to become commercially available. In the ETM it is assumed that the must-run variants of these technologies have a flat production profile i.e., they produce a constant amount of hydrogen throughout the year.
 
-Dedicated offshore wind turbines and solar PV plants are renewable energy plants built solely for hydrogen production. These plants turn renewable electricity directly into hydrogen using electrolysis. In addition, in the ETM hydrogen can be produced by a hybrid offshore wind installation. Electricity for hydrogen production is either provided by offshore wind turbines or from the HV network on land to the offshore electrolyser. See [Hybrid offshore wind](hybrid-offshore-wind) for more information on the components and behaviour of this hybrid offshore hub. To date, dedicated or hybrid plants are not (yet) used at a large scale. Their production profile is determined by solar and wind weather curves. 
+Dedicated offshore wind turbines and solar PV plants are renewable energy plants built solely for hydrogen production. These plants turn renewable electricity directly into hydrogen using electrolysis. In addition, in the ETM hydrogen can be produced by a hybrid offshore wind installation. Electricity for hydrogen production is either provided by offshore wind turbines or from the HV network on land to the offshore electrolyser. See [Hybrid offshore wind](hybrid-offshore-wind) for more information on the components and behaviour of this hybrid offshore hub. To date, dedicated or hybrid plants are not (yet) used at a large scale. Their production profile is determined by solar and wind weather curves.
 
-Additionally, price-sensitive hydrogen production with electrolysers can be installed. This technology is also known as power-to-gas. See [Power-to-gas](electricity-conversion#power-to-gas) for more information.
+Additionally, price-sensitive hydrogen production with electrolysers can be installed. See [Electrolysis](electricity-conversion#electrolysis-from-grid-on-land) for more information.
 
-:::info Power-to-gas as inflexible producer
-Power-to-gas produces hydrogen depending on the electicity price and is therefore considered a flexible consumer of electricity. It therefore produces hydrogen, regardless of the demand for hydrogen at any given moment. Therefore, this technology is considered an inflexible hydrogen producer.
+:::info Electrolysis as inflexible producer
+Electrolysis produces hydrogen depending on the electicity price and is therefore considered a flexible consumer of electricity. It therefore produces hydrogen, regardless of the demand for hydrogen at any given moment. Therefore, this technology is considered an inflexible hydrogen producer.
 :::
 
-Finally, you can choose to import hydrogen from abroad. Baseload import is assumed to be constant throughout the year. You can specify the costs of imported hydrogen in the [Cost & efficiencies section](https://energytransitionmodel.com/scenario/costs/costs_hydrogen/hydrogen-import) and adjust the [CO<sub>2</sub> emissions](https://energytransitionmodel.com/scenario/emissions/emission_factors/co2-emissions-of-imported-hydrogen-carriers-and-ammmonia) of imported hydrogen. 
+Finally, you can choose to import hydrogen from abroad. Baseload import is assumed to be constant throughout the year. You can specify the costs of imported hydrogen in the [Cost & efficiencies section](https://energytransitionmodel.com/scenario/costs/costs_hydrogen/hydrogen-import) and adjust the [CO<sub>2</sub> emissions](https://energytransitionmodel.com/scenario/emissions/emission_factors/co2-emissions-of-imported-hydrogen-carriers-and-ammmonia) of imported hydrogen.
 
 ### Dispatchable
 Dispatchable hydrogen sources include all hydrogen sources that can be turned on and off at will. These sources are therefore considered flexible. Their production profiles are determined dynamically: in a given hour, dispatchable hydrogen sources will only produce hydrogen if the inflexible demand in that hour exceeds supply of must-run producers. Dispatchables will switch on to ensure that supply matches demand. The ETM models the following dispatchable hydrogen sources:
 
 * Steam methane reforming (SMR)
-* Autothermal reforming (ATR) 
+* Autothermal reforming (ATR)
 * Ammonia reforming
 * Salt caverns for hydrogen storage
 * Depleted gas fields for hydrogen storage
@@ -54,13 +54,13 @@ Dispatchable hydrogen sources include all hydrogen sources that can be turned on
 
 For SMR, ATR and ammonia reforming the dispatchable installed capacity can be set. Furthermore, in case of a shortage caused by inflexible hydrogen demand the storage technologies can function as a flexible hydrogen source by releasing stored hydrogen. See [hydrogen storage](hydrogen.md#hydrogen-storage) for more information. As a last resort, the back-up import functions as flexible supply for the remaining shortage caused by inflexible hydrogen demand.
 
-The order in which the dispatchable sources of hydrogen are deployed can be altered in the merit order of dispatchable hydrogen producers. See [merit orders](hydrogen.md#merit-orders) for more information. 
+The order in which the dispatchable sources of hydrogen are deployed can be altered in the merit order of dispatchable hydrogen producers. See [merit orders](hydrogen.md#merit-orders) for more information.
 
 ![Hourly hydrogen production chart](/img/docs/20240314_hydrogen_production.png)
 
 ## Hydrogen demand
 
-Similar to hydrogen production, hydrogen demand is composed of inflexible and flexible demand. 
+Similar to hydrogen production, hydrogen demand is composed of inflexible and flexible demand.
 
 ### Inflexible demand
 In the ETM, the inflexible hydrogen demand categories are the following:
@@ -74,7 +74,7 @@ In the ETM, the inflexible hydrogen demand categories are the following:
 * Synthetic kerosene production
 * Baseload export
 
-Each of these options has its own hourly demand profile. For electricity production the demand profile is determined by the electricity market in your scenario. See [Merit Order](merit-order.md) for more information. 
+Each of these options has its own hourly demand profile. For electricity production the demand profile is determined by the electricity market in your scenario. See [Merit Order](merit-order.md) for more information.
 
 ### Flexible demand
 In case of overproduction by inflexible hydrogen supply (must-run producers), flexible hydrogen demand can be deployed to balance hydrogen supply and demand. Flexible demand is composed of:
@@ -85,13 +85,13 @@ In case of overproduction by inflexible hydrogen supply (must-run producers), fl
 
 The storage technologies can function as flexible demand by storing overproduction of hydrogen from inflexible hydrogen producers. See [hydrogen storage](hydrogen.md#hydrogen-storage) for more information on the hydrogen storage technologies. As a last resort, the back-up export functions as flexible demand for the remaining overproduction of inflexible hydrogen supply.
 
-The order in which the flexible demand categories are deployed can be altered in the merit order of dispatchable hydrogen demand. See [merit orders](hydrogen.md#merit-orders) for more information. 
+The order in which the flexible demand categories are deployed can be altered in the merit order of dispatchable hydrogen demand. See [merit orders](hydrogen.md#merit-orders) for more information.
 
 ![Hourly hydrogen demand chart](/img/docs/20240314_hydrogen_demand.png)
 
 ## Hydrogen storage
 
-The ETM calculates inflexible hydrogen demand and inflexible supply on an hourly-basis which makes it possible to identify moments of excess hydrogen production and shortages. To make sure that hydrogen supply matches demand throughout the year, flexible demand and flexible supply can be deployed. Hydrogen storage technologies have the ability to be deployed as both flexible demand and supply. 
+The ETM calculates inflexible hydrogen demand and inflexible supply on an hourly-basis which makes it possible to identify moments of excess hydrogen production and shortages. To make sure that hydrogen supply matches demand throughout the year, flexible demand and flexible supply can be deployed. Hydrogen storage technologies have the ability to be deployed as both flexible demand and supply.
 
 In the ETM, two hydrogen storage technologies are available:
 
@@ -106,9 +106,9 @@ Generally, salt caverns are better suited to deliver short-term flexibility whil
 
 ![Hourly hydrogen storage chart](/img/docs/20240314_hydrogen_storage.png)
 
-## Merit orders 
+## Merit orders
 
-The ETM ensures that total hydrogen demand and supply per hour are equal for every scenario. In case of overproduction or shortage caused by either inflexible supply or inflexible demand, flexible production technologies and flexible demand are deployed for balancing. A hydrogen 'merit order' for both flexible demand and supply determines the order in which the flexible demand and supply categories are switched in case of imbalance caused by inflexible demand or supply. The storage technologies can either function as flexible demand or flexible supply, and therefore are included in both merit orders. 
+The ETM ensures that total hydrogen demand and supply per hour are equal for every scenario. In case of overproduction or shortage caused by either inflexible supply or inflexible demand, flexible production technologies and flexible demand are deployed for balancing. A hydrogen 'merit order' for both flexible demand and supply determines the order in which the flexible demand and supply categories are switched in case of imbalance caused by inflexible demand or supply. The storage technologies can either function as flexible demand or flexible supply, and therefore are included in both merit orders.
 
 ### Merit order of dispatchable production
 In the merit order of dispatchable hydrogen production, the order of the following flexible producers can be set:
@@ -118,9 +118,9 @@ In the merit order of dispatchable hydrogen production, the order of the followi
 * Autothermal reforming (dispatchable)
 * Steam methane reforming (dispatchable)
 
-The back-up hydrogen import comes last ('lender of last resort'). By default, the two hydrogen storage options are set first. 
+The back-up hydrogen import comes last ('lender of last resort'). By default, the two hydrogen storage options are set first.
 
-<div class="text--center"> 
+<div class="text--center">
 <img src="/img/docs/20240314_hydrogen_merit_order_production.png" alt="Merit order of dispatchable hydrogen production" style={{width: 550}} />
 </div>
 
@@ -131,7 +131,7 @@ The order of the following flexible demand options can be set in the merit order
 
 The back-up hydrogen export comes last.
 
-<div class="text--center"> 
+<div class="text--center">
 <img src="/img/docs/20240314_hydrogen_merit_order_demand.png" alt="Merit order of dispatchable hydrogen demand" style={{width: 550}} />
 </div>
 

--- a/docs/main/residual-heat-industry.md
+++ b/docs/main/residual-heat-industry.md
@@ -2,7 +2,7 @@
 title:  Industrial residual heat
 ---
 
-There is a lot of heat available in industry that currently goes to waste. Using this residual heat as a source for heat networks could be an interesting way to reduce emissions. 
+There is a lot of heat available in industry that currently goes to waste. Using this residual heat as a source for heat networks could be an interesting way to reduce emissions.
 
 The ETM allows you to specify the amount of residual heat (in PJ) that the industry as a whole provides to heat networks. You can manually set the amount of heat delivered to each temperature level (high-temperature, medium-temperature and low-temperature) in the Supply > ['District Heating'](https://pro.energytransitionmodel.com/scenario/supply/heat/heat-sources) section within the ETM.
 
@@ -16,7 +16,7 @@ Although the upper limit of the residual heat sliders is quite high, in reality 
 -   Refineries
 -   Fertilizer industry
 -   ICT
--   Hydrogen conversion of electricity via power-to-gas
+-   Hydrogen conversion of electricity via electrolysis
 
 The above sectors are chosen because of their high residual heat potential compared to other sectors and/or because these sectors are similarly modelled in the ETM.
 

--- a/docs/main/residual-heat-industry.md
+++ b/docs/main/residual-heat-industry.md
@@ -16,7 +16,7 @@ Although the upper limit of the residual heat sliders is quite high, in reality 
 -   Refineries
 -   Fertilizer industry
 -   ICT
--   Hydrogen conversion of electricity via electrolysis
+-   Hydrogen production via electrolysis
 
 The above sectors are chosen because of their high residual heat potential compared to other sectors and/or because these sectors are similarly modelled in the ETM.
 

--- a/docs/main/user_manual/interface.md
+++ b/docs/main/user_manual/interface.md
@@ -2,7 +2,7 @@
 title: "Interface"
 ---
 
-This page explains the main features displayed in the [interface](https://energytransitionmodel.com/scenario/overview/scenario_overview/overview) of the ETM.
+This page efxplains the main features displayed in the [interface](https://energytransitionmodel.com/scenario/overview/scenario_overview/overview) of the ETM.
 You will land in the ETM interface after starting or opening a scenario. Here you will find the following topics:
 
 ![The ETM interface](/img/docs/interface.png)
@@ -20,7 +20,7 @@ In this section an overview of your scenario using summarizing charts can be fou
 The toolbar allows you to influence the main elements of the future energy system in your region:
 Demand: 	what happens to energy consumption in the future?
 Supply: 	which technologies will be used to produce heat, electricity and fuel in the future?
-Flexibility: 	future energy systems will most likely be characterized by times of excess electricity due to the volatile nature of the electricity production. Flexibility technologies, like battery storage and power to gas allow you to deal with this excess electricity.
+Flexibility: 	future energy systems will most likely be characterized by times of excess electricity due to the volatile nature of the electricity production. Flexibility technologies, like battery storage and electrolysis allow you to deal with this excess electricity.
 Emissions: what role will greenhouse gasses and CCUS play in the future?
 Costs & efficiencies: 	pecify what you think will happen to the costs of carriers and technologies.
 

--- a/docs/main/user_manual/interface.md
+++ b/docs/main/user_manual/interface.md
@@ -2,7 +2,7 @@
 title: "Interface"
 ---
 
-This page efxplains the main features displayed in the [interface](https://energytransitionmodel.com/scenario/overview/scenario_overview/overview) of the ETM.
+This page explains the main features displayed in the [interface](https://energytransitionmodel.com/scenario/overview/scenario_overview/overview) of the ETM.
 You will land in the ETM interface after starting or opening a scenario. Here you will find the following topics:
 
 ![The ETM interface](/img/docs/interface.png)
@@ -18,13 +18,13 @@ In this section an overview of your scenario using summarizing charts can be fou
 
 ### 4. Toolbar
 The toolbar allows you to influence the main elements of the future energy system in your region:
-Demand: 	what happens to energy consumption in the future?
-Supply: 	which technologies will be used to produce heat, electricity and fuel in the future?
-Flexibility: 	future energy systems will most likely be characterized by times of excess electricity due to the volatile nature of the electricity production. Flexibility technologies, like battery storage and electrolysis allow you to deal with this excess electricity.
-Emissions: what role will greenhouse gasses and CCUS play in the future?
-Costs & efficiencies: 	pecify what you think will happen to the costs of carriers and technologies.
+* Demand: what happens to energy consumption in the future?
+* Supply: which technologies will be used to produce heat, electricity and fuel in the future?
+* Flexibility: future energy systems will most likely be characterized by times of excess electricity due to the volatile nature of the electricity production. Flexibility technologies, like battery storage and electrolysis allow you to deal with this excess electricity.
+* Emissions: what role will greenhouse gasses and CCUS play in the future?
+* Costs & efficiencies: specify what you think will happen to the costs of carriers and technologies.
 
-Checkout: the Detailed Explanations section for more information on calculations and definitions.
+Checkout the sections under Detailed information for more information on calculations and definitions.
 
 ### 5. Tools and sliders
 In the ETM you can use sliders to manipulate the current situation to produce a future energy scenario. You can either:


### PR DESCRIPTION
#### Context
The labelling of electrolysis is not consistent in the model and should be revised.

#### Implemented changes
- Updated descriptions by renaming power-to-gas to electrolysis.
- Updated the title of section "Power-to-gas" located under Flexibility>Electricity > Electricity conversion> Description of Technologies
- Updated the link to renamed section. This link is located in Hydrogen production. 
- Note: power-to-gas is not renamed in Overview of costs per sector > Storage and conversion.

#### Related

Closes issue: https://github.com/quintel/etsource/issues/3086

Goes with pull requests: 
- https://github.com/quintel/etmodel/pull/4707
- https://github.com/quintel/etengine/pull/1737
- https://github.com/quintel/documentation/pull/310
- https://github.com/quintel/etsource/pull/3439

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review
