### PR TITLE
Add discard passthrough documentation

### DIFF
--- a/data/api/collections.js
+++ b/data/api/collections.js
@@ -56,6 +56,20 @@ export default {
           </ul>`,
         required: false,
       },
+      {
+        name: "area_code",
+        type: "string",
+        description:
+          "the area code for the collection (optional; auto-filled from saved scenarios for transition paths)",
+        required: false,
+      },
+      {
+        name: "end_year",
+        type: "number",
+        description:
+          "the end year for the collection (optional; auto-filled from saved scenarios for transition paths)",
+        required: false,
+      },
     ],
     token: { scopes: ["scenarios:read", "scenarios:write"] },
   },
@@ -86,6 +100,18 @@ export default {
         type: "boolean",
         description:
           "whether the collection should be in the owner's trash",
+      },
+      {
+        name: "area_code",
+        type: "string",
+        description:
+          "the area code for the collection",
+      },
+      {
+        name: "end_year",
+        type: "number",
+        description:
+          "the end year for the collection",
       },
     ],
     token: { scopes: ["scenarios:read", "scenarios:write"] },

--- a/data/api/saved-scenarios.js
+++ b/data/api/saved-scenarios.js
@@ -90,6 +90,12 @@ export default {
     ],
     token: { scopes: ["scenarios:read", "scenarios:write"] },
   },
+  discard: {
+    endpoint: "/api/v3/saved_scenarios/{id}/discard",
+    method: "PUT",
+    path_parameters: [scenarioIdParam],
+    token: { scopes: ["scenarios:read", "scenarios:delete"] },
+  },
   destroy: {
     endpoint: "/api/v3/saved_scenarios/{id}",
     method: "DELETE",

--- a/docs/api/collections.md
+++ b/docs/api/collections.md
@@ -37,6 +37,10 @@ collection endpoint:
   * `id` - the owner's unique ID number.
   * `name` - the owner's name.
 
+:::info Transition path parameters
+The `interpolation_params` object in API responses is automatically populated from the collection's `area_code` and `end_year` fields (shown as `end_years` array in the response). These are top-level input parameters when creating or updating a collection, and are auto-filled from saved scenarios for transition paths.
+:::
+
 ## Getting information about a collection
 
 Fetch information about a collection.
@@ -119,6 +123,10 @@ Creating a collection will cause it to appear in your list and in the web applic
 
 Before you can create a **collection**, you must [create the underlying **scenarios**](scenarios.md#create-a-scenario) or [**saved scenarios**](saved-scenarios#create-a-saved-scenario). The response will include the ID number of your new scenario. You may then create a collection as a second step, passing the scenario IDs:
 
+:::info Auto-filled attributes
+The API automatically fills in `version` for all collections. For transition paths (`interpolation: true`) with saved scenarios, `area_code` and `end_year` are also auto-filled from the saved scenarios if not explicitly provided.
+:::
+
 ```http title="Example request"
 POST /api/v3/collections HTTP/2
 Host: engine.energytransitionmodel.com
@@ -128,7 +136,8 @@ Authorization: Bearer YOUR_TOKEN
 {
   "title": "My collection",
   "scenario_ids": [12, 34],
-  "saved_scenario_ids": [5, 6]
+  "saved_scenario_ids": [5, 6],
+  "discarded": false
 }
 ```
 
@@ -167,7 +176,8 @@ Authorization: Bearer YOUR_TOKEN
 {
   "title": "A new title",
   "scenario_ids": [45, 67],
-  "saved_scenario_ids": [89]
+  "saved_scenario_ids": [89],
+  "discarded": false
 }
 ```
 
@@ -189,6 +199,10 @@ Authorization: Bearer YOUR_TOKEN
   }
 }
 ```
+
+:::info Managing discarded collections
+You can move a collection to the trash by setting `discarded: true` when creating or updating it. To restore a collection from trash, update it with `discarded: false`. This allows you to manage your collections without permanently deleting them.
+:::
 
 ## Delete a collection
 

--- a/docs/api/exports.md
+++ b/docs/api/exports.md
@@ -21,6 +21,8 @@ Endpoints that can be used to retrieve annual data are based on the following da
 * `sankey` – Creates a CSV by reading the `sankey` configuration file from ETSource.
 * `storage_parameters` - Creates a CSV by reading the `storage` configuration file from ETSource.
 * `costs_parameters` - Returns a CSV file containing the cost parameters of nodes belonging to costs groups.
+* `direct_emissions_present` - Returns a CSV file containing the direct emissions by node in the present scenario year.
+* `direct_emissions_future` - Returns a CSV file containing the direct emissions by node in the future scenario year.
 
 
 ## Get annual data

--- a/docs/api/saved-scenarios.md
+++ b/docs/api/saved-scenarios.md
@@ -161,6 +161,10 @@ Creating a saved scenario will cause it to appear in your list of saved scenario
 
 Before you can create a **saved scenario**, you must [create the underlying **scenario**](scenarios.md#create-a-scenario). The response will include the ID number of your new scenario. You may then create a saved scenario as a second step, passing the scenario ID:
 
+:::info Auto-filled attributes
+The API automatically fills in `area_code`, `end_year`, and `version` from the underlying scenario. You don't need to provide these fields - they will be populated from the scenario you reference.
+:::
+
 ```http title="Example request"
 POST /api/v3/saved_scenarios HTTP/2
 Host: engine.energytransitionmodel.com
@@ -168,8 +172,10 @@ Accept: application/json
 Authorization: Bearer YOUR_TOKEN
 
 {
-  "scenario_id": 12345,
-  "title": "My saved scenario"
+  "saved_scenario": {
+    "scenario_id": 12345,
+    "title": "My saved scenario"
+  }
 }
 ```
 
@@ -212,8 +218,10 @@ Accept: application/json
 Authorization: Bearer YOUR_TOKEN
 
 {
-  "title": "A new title",
-  "scenario_id": 67890
+  "saved_scenario": {
+    "title": "A new title",
+    "scenario_id": 67890
+  }
 }
 ```
 
@@ -273,6 +281,30 @@ Every saved scenario must have at least one owner. The API will prevent you from
 :::
 
 See also the [saved scenario access](/main/user_manual/managing-scenarios/scenario-manage-access) page for more information.
+
+### User object structure
+
+Each user object in the `saved_scenario_users` array has the following structure:
+
+**For adding users (POST):**
+* `user_email` - the email address of the user (required if `user_id` not provided)
+* `user_id` - the numeric ID of an existing ETM user (required if `user_email` not provided)
+* `role` - the user's role: `"scenario_owner"`, `"scenario_collaborator"`, or `"scenario_viewer"` (required)
+
+**For updating users (PUT):**
+* `id` - the SavedScenarioUser ID (optional, for identification)
+* `user_id` - the numeric ID of an existing ETM user (optional, for identification)
+* `user_email` - the email address of the user (optional, for identification)
+* `role` - the new role to assign (required)
+
+**For removing users (DELETE):**
+* `id` - the SavedScenarioUser ID (optional, for identification)
+* `user_id` - the numeric ID of an existing ETM user (optional, for identification)
+* `user_email` - the email address of the user (optional, for identification)
+
+:::info Identifying users
+When adding users, you must provide either `user_email` OR `user_id`, but not both. When updating or removing users, you can identify them by `id`, `user_id`, or `user_email` - at least one must be provided.
+:::
 
 ### Listing users on a saved scenario
 
@@ -458,12 +490,26 @@ User management operations support partial success:
 When a bulk operation returns partial success, the successful changes **are persisted** to the database. Only the failed operations need to be retried.
 :::
 
-Common errors include:
+#### Validation rules
+
+The API validates user objects according to these rules:
+
+* **User identification**: When adding users, you must provide either `user_email` OR `user_id`, but not both
+* **Email format**: If providing `user_email`, it must be a valid email address format
+* **Role values**: The `role` must be one of: `"scenario_viewer"`, `"scenario_collaborator"`, or `"scenario_owner"`
+* **Last owner protection**: Every saved scenario must have at least one owner - you cannot remove or demote the last owner
+* **Duplicate prevention**: Cannot add a user who is already associated with the saved scenario
+
+#### Common errors
+
+When validation fails, you'll receive a `422 Unprocessable Entity` response with one of these error codes:
 
 * `duplicate` - User is already associated with the saved scenario
-* `role_id` - Invalid role specified
+* `role_id` - Invalid role specified (must be scenario_viewer, scenario_collaborator, or scenario_owner)
 * `not_found` - User not found when updating or removing
 * `ownership` - Cannot remove or change the last owner
+* `user_email` - Invalid email format or missing when user_id not provided
+* `user_id` - Missing when user_email not provided
 
 For managing users on regular scenarios (not saved scenarios), see [Scenario Users](/api/users).
 
@@ -649,8 +695,10 @@ Accept: application/json
 Authorization: Bearer YOUR_TOKEN
 
 {
-  // highlight-next-line
-  "scenario_id": 123457
+  "saved_scenario": {
+    // highlight-next-line
+    "scenario_id": 123457
+  }
 }
 ```
 
@@ -671,6 +719,32 @@ The saved scenario now points at your new scenario, and the the original scenari
 
 </li>
 </ol>
+
+## Discard a saved scenario
+
+Saved scenarios can be moved to the trash (discarded) without permanently deleting them. This sets the `discarded_at` timestamp and marks the scenario as discarded, making it appear in the trash instead of your regular saved scenarios list.
+
+<ApiEndpoint data={endpointData.discard} />
+
+```http title="Example request"
+PUT /api/v3/saved_scenarios/123/discard HTTP/2
+Host: engine.energytransitionmodel.com
+Authorization: Bearer YOUR_TOKEN
+```
+
+```json title="Example response"
+{
+  "message": "Scenario discarded successfully"
+}
+```
+
+:::info Preserving timestamps
+Discarding a scenario sets the `discarded_at` field but preserves the original `updated_at` timestamp. This ensures the modification history remains accurate.
+:::
+
+:::tip Undiscarding
+Discarded scenarios can be restored through the web interface. The API currently does not support undiscarding scenarios.
+:::
 
 ## Delete a saved scenario
 


### PR DESCRIPTION
#### Context
Recent changes to the endpoints to enable discard as a passthrough and enhance collections management were not completely documented. This PR addresses that and refines some of the other API documentation related to more recent API changes (such as collections parameters and saved scenario users).

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review
