### PR TITLE
Add documentation for the hide_label option

### DIFF
--- a/docs/contrib/charts/category-bar.md
+++ b/docs/contrib/charts/category-bar.md
@@ -100,3 +100,15 @@ For example, the first category may use values 100, 105, 110, 115; the second ca
 ### `output_element_key`
 
 The key of the chart to which the series belongs.
+
+## Universal series attributes
+
+Some series attributes work across multiple chart types. These include:
+
+### `hide_label`
+
+When set to `true`, the series will not appear in the chart legend. This is useful when you have duplicate series representing the same category but for different time periods (e.g., present/future values and 1990 baseline values), preventing cluttered legends with redundant entries.
+
+This attribute is optional and defaults to `false` when omitted.
+
+This attribute works with all chart types that use legends, including category bar, vertical stacked bar, bezier, and line charts.


### PR DESCRIPTION
#### Context
A lot of the ETModel chart feature options are not well documented, and in the future the new UI should be documented for contributors more thoroughly. For now I think this is a minimal change covering the changes in [this etmodel PR, adding the hide_label attribute](https://github.com/quintel/etmodel/pull/4726).