### PR TITLE
Update curve export documentation to reflect renamed endpoints and ne…

### DIFF
--- a/data/releases.js
+++ b/data/releases.js
@@ -200,6 +200,12 @@ export const mainReleases = [
 // API changelog timeline data
 export const apiChangelog = [
   {
+    date: "Jun 25, 2026",
+    title: "New capacity exports and renamed hourly curve endpoints",
+    file: "2026-06.md",
+    tag: "2026-06",
+  },
+  {
     date: "Mar 5, 2026",
     title: "Present year energy flow export",
     file: "2026-02.md",

--- a/docs/api/exports.md
+++ b/docs/api/exports.md
@@ -14,7 +14,6 @@ as well as hourly data.
 
 Endpoints that can be used to retrieve annual data are based on the following data keys:
 
-* `production_parameters` - Returns a CSV file containing the capacities and costs of some electricity and heat producers.
 * `energy_flow` - Returns a CSV file containing the energetic inputs and outputs of every node in the graph of the future scenario year.
 * `energy_flow_present` - Returns a CSV file containing the energetic inputs and outputs of every node in the graph of the present dataset year.
 * `molecule_flow` - Returns a CSV file containing the flow of molecules through the molecule graph.
@@ -47,15 +46,19 @@ Primary demand,Electricity,...
 
 Endpoints that can be used to retrieve hourly data are based on the following data keys:
 
-* `merit_order` -Downloads the load on each participant in the electricity merit order.
+* `electricity_profiles` - Downloads the load on each participant in the electricity merit order.
+* `electricity_capacities` - Downloads the installed and peak capacity per electricity participant.
 * `electricity_price` - Downloads the hourly price of electricity according to the merit order.
-* `heat_network` - Downloads the load on each participant in the heat merit order as a CSV.
+* `heat_network_profiles` - Downloads the load on each participant in the heat merit order as a CSV.
+* `heat_network_capacities` - Downloads the installed and peak capacity per heat network participant.
 * `agriculture_heat` - Downloads the load on each participant in the agriculture heat merit order as a CSV.
 * `household_heat` – Downloads the supply and demand of heat in households, including deficits and surpluses due to buffering and time-shifting.
 * `buildings_heat` - Downloads the supply and demand of heat in buildings, including deficits and surpluses due to buffering and time-shifting.
-* `hydrogen` - Downloads the total demand and supply for hydrogen, with additional columns for the storage demand and supply.
-* `hydrogen_integral_costs` - Downloads the levelised costs, production costs per MWh and hourly production curve per hydrogen production technology.
-* `network_gas` - Downloads the total demand and supply for network gas, with additional columns for the storage demand and supply.
+* `hydrogen_profiles` - Downloads the total demand and supply for hydrogen, with additional columns for the storage demand and supply.
+* `hydrogen_capacities` - Downloads the installed and peak capacity per hydrogen participant.
+* `hydrogen_integral_cost` - Downloads the levelised costs, production costs per MWh and hourly production curve per hydrogen production technology.
+* `network_gas_profiles` - Downloads the total demand and supply for network gas, with additional columns for the storage demand and supply.
+* `network_gas_capacities` - Downloads the installed and peak capacity per network gas participant.
 * `residual_load` - Downloads the residual loads of various carriers.
 
 
@@ -66,7 +69,7 @@ Sending a GET request for a `csv` file with one of the keys specified above to a
 <ApiEndpoint data={endpointData.curves} />
 
 ```http title="Example request"
-GET /api/v3/scenarios/0/curves/hydrogen.csv HTTP/2
+GET /api/v3/scenarios/0/curves/hydrogen_profiles.csv HTTP/2
 Host: engine.energytransitionmodel.com
 Accept: text/csv
 ```

--- a/docs/api/exports.md
+++ b/docs/api/exports.md
@@ -49,8 +49,8 @@ Endpoints that can be used to retrieve hourly data are based on the following da
 * `electricity_profiles` - Downloads the load on each participant in the electricity merit order.
 * `electricity_capacities` - Downloads the installed and peak capacity per electricity participant.
 * `electricity_price` - Downloads the hourly price of electricity according to the merit order.
-* `heat_network_profiles` - Downloads the load on each participant in the heat merit order as a CSV.
-* `heat_network_capacities` - Downloads the installed and peak capacity per heat network participant.
+* `district_heating_profiles` - Downloads the load on each participant in the district heating network merit order as a CSV.
+* `district_heating_capacities` - Downloads the installed and peak capacity per district heating network participant.
 * `agriculture_heat` - Downloads the load on each participant in the agriculture heat merit order as a CSV.
 * `household_heat` – Downloads the supply and demand of heat in households, including deficits and surpluses due to buffering and time-shifting.
 * `buildings_heat` - Downloads the supply and demand of heat in buildings, including deficits and surpluses due to buffering and time-shifting.

--- a/static/api-changelog/2026-06.md
+++ b/static/api-changelog/2026-06.md
@@ -1,0 +1,2 @@
+* Four new capacity exports added: `electricity_capacities`, `hydrogen_capacities`, `network_gas_capacities`, and `heat_network_capacities`, providing installed and peak capacity per participant. [Learn more here.](/api/exports)
+* The hourly curve export endpoints have been renamed for consistency: `merit_order` → `electricity_profiles`, `heat_network` → `heat_network_profiles`, `hydrogen` → `hydrogen_profiles`, `network_gas` → `network_gas_profiles`. The old endpoint names remain available as backwards-compatible aliases for the time being. [Learn more here.](/api/exports)


### PR DESCRIPTION
#### Context

The hourly curve exports allow users to download the load per participant per hour for electricity, hydrogen, network gas, and heat networks. However, there was no way to download the installed and peak capacity of each participant. This set of PRs adds 4 new CSV exports, one per carrier group, with that information.

#### Implemented changes

- Updated hourly curve endpoint names to reflect the `_profiles` suffix renaming
- Added the 4 new capacity endpoints (`electricity_capacities`, `hydrogen_capacities`, `network_gas_capacities`, `heat_network_capacities`)
- Removed the deprecated `production_parameters` entry

#### Related

Set of 3 pull requests:
- etengine: https://github.com/quintel/etengine/pull/1767
  - continuation: https://github.com/quintel/etengine/pull/1768
- etmodel: https://github.com/quintel/etmodel/pull/4724
  - continuation: https://github.com/quintel/etmodel/pull/4729
- documentation: https://github.com/quintel/documentation/pull/329 [This one]

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review
